### PR TITLE
fix: allow pkg subpath import

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     ".": {
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
-    }
+    },
+    "./": "./"
   },
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },
-    "./": "./"
+    "./*": "./*"
   },
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
Seems like #7 has been reintroduced through https://github.com/unjs/ufo/commit/7c26571f0b5df2b93a694f4787cac4b6bdf73625.

This PR resolves it again (but there might be a better solution as it had been removed intentionally in https://github.com/unjs/ufo/commit/be3b1ae3a5880e5127006a7b86362fd833b4992a ?).

Resolves: https://github.com/nuxt/framework/issues/118
