### PR TITLE
fix: slash encode in path

### DIFF
--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -18,6 +18,8 @@ const ENC_CURLY_OPEN_RE = /%7B/g // {
 const ENC_PIPE_RE = /%7C/g // |
 const ENC_CURLY_CLOSE_RE = /%7D/g // }
 const ENC_SPACE_RE = /%20/g
+const ENC_SLASH_RE = /%2F/g
+const ENC_ENC_SLASH_RE = /%252F/g
 
 /**
  * Encode characters that need to be encoded on the path, search and hash
@@ -85,7 +87,7 @@ export function encodeQueryKey (text: string | number): string {
  * @returns encoded string
  */
 export function encodePath (text: string | number): string {
-  return encode(text).replace(HASH_RE, '%23').replace(IM_RE, '%3F')
+  return encode(text).replace(HASH_RE, '%23').replace(IM_RE, '%3F').replace(ENC_ENC_SLASH_RE, '%2F')
 }
 
 /**
@@ -113,6 +115,16 @@ export function decode (text: string | number = ''): string {
   } catch (_err) {
     return '' + text
   }
+}
+
+/**
+ * Decode path section of URL (consitant with encodePath for slash encoding).
+ *
+ * @param text - string to decode
+ * @returns decoded string
+ */
+export function decodePath (text: string): string {
+  return decode(text.replace(ENC_SLASH_RE, '%252F'))
 }
 
 /**

--- a/src/url.ts
+++ b/src/url.ts
@@ -1,7 +1,7 @@
 import { parseURL, parseAuth, parseHost } from './parse'
 import { QueryObject, parseQuery, stringifyQuery } from './query'
 import { withoutLeadingSlash, withTrailingSlash } from './utils'
-import { encodeHash, encodePath, decode, encodeHost } from './encoding'
+import { encodeHash, encodePath, decodePath, decode, encodeHost } from './encoding'
 
 export class $URL implements URL {
   protocol: string
@@ -21,7 +21,7 @@ export class $URL implements URL {
     this.protocol = decode(parsed.protocol)
     this.host = decode(parsed.host)
     this.auth = decode(parsed.auth)
-    this.pathname = decode(parsed.pathname)
+    this.pathname = decodePath(parsed.pathname)
     this.query = parseQuery(parsed.search)
     this.hash = decode(parsed.hash)
   }

--- a/test/normalize.test.ts
+++ b/test/normalize.test.ts
@@ -28,7 +28,8 @@ describe('normalizeURL', () => {
     'http://[2001:db8:85a3:8d3:1319:8a2e:370:7348]/': 'http://[2001:db8:85a3:8d3:1319:8a2e:370:7348]/',
     'http://localhost/?redirect=http://google.com?q=test': 'http://localhost/?redirect=http://google.com?q=test',
     'http://localhost/?email=some+v1@email.com': 'http://localhost/?email=some+v1@email.com',
-    'http://localhost/?email=some%2Bv1%40email.com': 'http://localhost/?email=some%2Bv1@email.com'
+    'http://localhost/?email=some%2Bv1%40email.com': 'http://localhost/?email=some%2Bv1@email.com',
+    'http://localhost/abc/deg%2F%2Ftest?email=some+v1@email.com': 'http://localhost/abc/deg%2F%2Ftest?email=some+v1@email.com'
   }
 
   const validURLS = [


### PR DESCRIPTION
Fix for issue https://github.com/unjs/ufo/issues/22
Only preventing decoding of encoded slash in pathname part of URL.
