### PR TITLE
feat: support query params for `trailingSlash` utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ Ensures url ends with a trailing slash
 withTrailingSlash('/foo')
 ```
 
+```ts
+// Result: /path/?query=true
+withTrailingSlash('/path?query=true', true)
+```
+
 ### `withoutTrailingSlash`
 
 Ensures url does not ends with a trailing slash
@@ -104,6 +109,11 @@ Ensures url does not ends with a trailing slash
 ```ts
 // Result: /foo
 withoutTrailingSlash('/foo/')
+```
+
+```ts
+// Result: /path?query=true
+withoutTrailingSlash('/path/?query=true', true)
 ```
 
 ### `cleanDoubleSlashes`

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,16 +11,26 @@ export function hasProtocol (inputStr: string, acceptProtocolRelative = false): 
   return /^\w+:\/\/.+/.test(inputStr) || (acceptProtocolRelative && /^\/\/[^/]+/.test(inputStr))
 }
 
+const TRAILING_SLASH_RE = /\/$|\/\?/
+
 export function hasTrailingSlash (input: string = ''): boolean {
-  return input.endsWith('/')
+  return TRAILING_SLASH_RE.test(input)
 }
 
 export function withoutTrailingSlash (input: string = ''): string {
-  return (hasTrailingSlash(input) ? input.slice(0, -1) : input) || '/'
+  if (!hasTrailingSlash(input)) {
+    return input || '/'
+  }
+  const [s0, ...s] = input.split('?')
+  return (s0.slice(0, -1) || '/') + (s.length ? `?${s.join('?')}` : '')
 }
 
 export function withTrailingSlash (input: string = ''): string {
-  return input.endsWith('/') ? input : (input + '/')
+  if (hasTrailingSlash(input)) {
+    return input || '/'
+  }
+  const [s0, ...s] = input.split('?')
+  return s0 + '/' + (s.length ? `?${s.join('?')}` : '')
 }
 
 export function hasLeadingSlash (input: string = ''): boolean {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,20 +13,29 @@ export function hasProtocol (inputStr: string, acceptProtocolRelative = false): 
 
 const TRAILING_SLASH_RE = /\/$|\/\?/
 
-export function hasTrailingSlash (input: string = ''): boolean {
+export function hasTrailingSlash (input: string = '', queryParams: boolean = false): boolean {
+  if (!queryParams) {
+    return input.endsWith('/')
+  }
   return TRAILING_SLASH_RE.test(input)
 }
 
-export function withoutTrailingSlash (input: string = ''): string {
-  if (!hasTrailingSlash(input)) {
+export function withoutTrailingSlash (input: string = '', queryParams: boolean = false): string {
+  if (!queryParams) {
+    return (hasTrailingSlash(input) ? input.slice(0, -1) : input) || '/'
+  }
+  if (!hasTrailingSlash(input, true)) {
     return input || '/'
   }
   const [s0, ...s] = input.split('?')
   return (s0.slice(0, -1) || '/') + (s.length ? `?${s.join('?')}` : '')
 }
 
-export function withTrailingSlash (input: string = ''): string {
-  if (hasTrailingSlash(input)) {
+export function withTrailingSlash (input: string = '', queryParams: boolean = false): string {
+  if (!queryParams) {
+    return input.endsWith('/') ? input : (input + '/')
+  }
+  if (hasTrailingSlash(input, true)) {
     return input || '/'
   }
   const [s0, ...s] = input.split('?')

--- a/test/trailing-slash.test.ts
+++ b/test/trailing-slash.test.ts
@@ -5,7 +5,9 @@ describe('withTrailingSlash', () => {
   const tests = {
     '': '/',
     bar: 'bar/',
-    'bar/': 'bar/'
+    'bar/': 'bar/',
+    'foo?123': 'foo/?123',
+    'foo/?123': 'foo/?123'
   }
 
   for (const input in tests) {
@@ -24,7 +26,9 @@ describe('withoutTrailingSlash', () => {
     '': '/',
     '/': '/',
     bar: 'bar',
-    'bar/': 'bar'
+    'bar/': 'bar',
+    'foo?123': 'foo?123',
+    'foo/?123': 'foo?123'
   }
 
   for (const input in tests) {

--- a/test/trailing-slash.test.ts
+++ b/test/trailing-slash.test.ts
@@ -1,13 +1,13 @@
 // @ts-nocheck
 import { withTrailingSlash, withoutTrailingSlash } from '../src'
 
-describe('withTrailingSlash', () => {
+describe('withTrailingSlash, queryParams: false', () => {
   const tests = {
     '': '/',
     bar: 'bar/',
     'bar/': 'bar/',
-    'foo?123': 'foo/?123',
-    'foo/?123': 'foo/?123'
+    'foo?123': 'foo?123/',
+    'foo/?123': 'foo/?123/'
   }
 
   for (const input in tests) {
@@ -21,7 +21,48 @@ describe('withTrailingSlash', () => {
   })
 })
 
-describe('withoutTrailingSlash', () => {
+describe('withTrailingSlash, queryParams: true', () => {
+  const tests = {
+    '': '/',
+    bar: 'bar/',
+    'bar/': 'bar/',
+    'foo?123': 'foo/?123',
+    'foo/?123': 'foo/?123'
+  }
+
+  for (const input in tests) {
+    test(input, () => {
+      expect(withTrailingSlash(input, true)).toBe(tests[input])
+    })
+  }
+
+  test('falsy value', () => {
+    expect(withTrailingSlash()).toBe('/')
+  })
+})
+
+describe('withoutTrailingSlash, queryParams: false', () => {
+  const tests = {
+    '': '/',
+    '/': '/',
+    bar: 'bar',
+    'bar/': 'bar',
+    'foo?123': 'foo?123',
+    'foo/?123': 'foo/?123'
+  }
+
+  for (const input in tests) {
+    test(input, () => {
+      expect(withoutTrailingSlash(input)).toBe(tests[input])
+    })
+  }
+
+  test('falsy value', () => {
+    expect(withoutTrailingSlash()).toBe('/')
+  })
+})
+
+describe('withoutTrailingSlash, queryParams: true', () => {
   const tests = {
     '': '/',
     '/': '/',
@@ -33,7 +74,7 @@ describe('withoutTrailingSlash', () => {
 
   for (const input in tests) {
     test(input, () => {
-      expect(withoutTrailingSlash(input)).toBe(tests[input])
+      expect(withoutTrailingSlash(input, true)).toBe(tests[input])
     })
   }
 


### PR DESCRIPTION
resolves #19

Support `ufo.withTrailingSlash('/path?a=1')` to be `/path?a=1/` when second argument is passed `true`

Downsides:
- Might introduce unwanted behavior when input is not URL (example: `/:param?` ~> `/:param/?`)
- Adding runtime overhead for cases that do not need this feature