### PR TITLE
fix(encodeQueryItem): stringify boolean values

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -35,7 +35,7 @@ export function parseQuery (paramsStr: string = ''): QueryObject {
 }
 
 export function encodeQueryItem (key: string, val: QueryValue): string {
-  if (typeof val === 'number') {
+  if (typeof val === 'number' || typeof val === 'boolean') {
     val = String(val)
   }
   if (!val) {

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -11,6 +11,7 @@ describe('withQuery', () => {
     { input: '/?test', query: { foo: 0 }, out: '/?test&foo=0' },
     { input: '/?test', query: { foo: 1 }, out: '/?test&foo=1' },
     { input: '/?foo=1', query: { foo: 2 }, out: '/?foo=2' },
+    { input: '/?foo=1', query: { foo: true, bar: false }, out: '/?foo=true&bar=false' },
     {
       input: '/',
       query: { email: 'some email.com' },


### PR DESCRIPTION
Handle boolean values in encodeQueryItem.

I was also wondering why not simply using the native URLSearchParams interface to encode query params ?