### PR TITLE
fix: encode `[]` and `{}` in query values to increase compatibility

### DIFF
--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -31,9 +31,7 @@ const ENC_ENC_SLASH_RE = /%252f/gi;
  */
 export function encode (text: string | number): string {
   return encodeURI("" + text)
-    .replace(ENC_PIPE_RE, "|")
-    .replace(ENC_BRACKET_OPEN_RE, "[")
-    .replace(ENC_BRACKET_CLOSE_RE, "]");
+    .replace(ENC_PIPE_RE, "|");
 }
 
 /**
@@ -65,8 +63,6 @@ export function encodeQueryValue (text: string | number): string {
       .replace(HASH_RE, "%23")
       .replace(AMPERSAND_RE, "%26")
       .replace(ENC_BACKTICK_RE, "`")
-      .replace(ENC_CURLY_OPEN_RE, "{")
-      .replace(ENC_CURLY_CLOSE_RE, "}")
       .replace(ENC_CARET_RE, "^")
   );
 }

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -10,8 +10,6 @@ const EQUAL_RE = /=/g; // %3D
 const IM_RE = /\?/g; // %3F
 const PLUS_RE = /\+/g; // %2B
 
-const ENC_BRACKET_OPEN_RE = /%5b/gi; // [
-const ENC_BRACKET_CLOSE_RE = /%5d/gi; // ]
 const ENC_CARET_RE = /%5e/gi; // ^
 const ENC_BACKTICK_RE = /%60/gi; // `
 const ENC_CURLY_OPEN_RE = /%7b/gi; // {

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -28,6 +28,7 @@ describe("withQuery", () => {
     },
     { input: "/?x=1,2,3", query: { y: "1,2,3" }, out: "/?x=1,2,3&y=1,2,3" },
     { input: "http://a.com?v=1", query: { x: 2 }, out: "http://a.com?v=1&x=2" },
+    { input: "/", query: { json: "{\"test\":[\"content\"]}" }, out: "/?json=%7B%22test%22:%5B%22content%22%5D%7D" },
     { input: "/", query: { param: ["3", ""] }, out: "/?param=3&param=" },
     { input: "/", query: { param: ["", "3"] }, out: "/?param=&param=3" }
   ];


### PR DESCRIPTION
Possible fix for encoding correctly query values.

Closes #105 