### PR TITLE
fix(hasProtocol): accept backslash too

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,7 +8,7 @@ export function isRelative(inputString: string) {
 }
 
 const PROTOCOL_REGEX = /^\w{2,}:(\/\/)?/;
-const PROTOCOL_RELATIVE_REGEX = /^\/\/[^/]+/;
+const PROTOCOL_RELATIVE_REGEX = /^[/\\]{2}[^/]+/;
 
 export function hasProtocol(
   inputString: string,

--- a/test/utilities.test.ts
+++ b/test/utilities.test.ts
@@ -24,6 +24,7 @@ describe("hasProtocol", () => {
     { input: "tel:", out: [true, true] },
     { input: "tel:123456", out: [true, true] },
     { input: "mailto:support@example.com", out: [true, true] },
+    { input: "/\\localhost//", out: [true, false] },
   ];
 
   for (const t of tests) {


### PR DESCRIPTION
A URL like `/\localhost` or `https:\/foo.com` can also have protocol. 

Notice we are already doing this normalization for parser (https://github.com/unjs/ufo/blob/9741e57547816901cd6539557adce163e73ffbde/src/parse.ts#L28)