### PR TITLE
feat: stringify query values

### DIFF
--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -1,5 +1,6 @@
 // @ts-ignore
 import { toASCII } from "./punycode";
+import { QueryValue } from "./query";
 
 // Utils used from https://github.com/vuejs/vue-router-next/blob/master/src/encoding.ts (Author @posva)
 
@@ -28,8 +29,7 @@ const ENC_ENC_SLASH_RE = /%252f/gi;
  * @returns encoded string
  */
 export function encode(text: string | number): string {
-  return encodeURI("" + text)
-    .replace(ENC_PIPE_RE, "|");
+  return encodeURI("" + text).replace(ENC_PIPE_RE, "|");
 }
 
 /**
@@ -49,12 +49,12 @@ export function encodeHash(text: string): string {
  * Encode characters that need to be encoded query values on the query
  * section of the URL.
  *
- * @param text - string to encode
+ * @param input - string to encode
  * @returns encoded string
  */
-export function encodeQueryValue(text: string | number): string {
+export function encodeQueryValue(input: QueryValue): string {
   return (
-    encode(text)
+    encode(typeof input === "string" ? input : JSON.stringify(input))
       // Encode the space as +, encode the + to differentiate it from the space
       .replace(PLUS_RE, "%2B")
       .replace(ENC_SPACE_RE, "+")

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -1,4 +1,3 @@
-// @ts-ignore
 import { toASCII } from "./punycode";
 import { QueryValue } from "./query";
 

--- a/src/query.ts
+++ b/src/query.ts
@@ -5,7 +5,12 @@ import {
   encodeQueryValue,
 } from "./encoding";
 
-export type QueryValue = string | undefined | null;
+export type QueryValue =
+  | string
+  | number
+  | undefined
+  | null
+  | Record<string, any>;
 export type QueryObject = Record<string, QueryValue | QueryValue[]>;
 
 export function parseQuery(parametersString = ""): QueryObject {

--- a/src/url.ts
+++ b/src/url.ts
@@ -72,7 +72,10 @@ export class $URL implements URL {
           p.append(name, v);
         }
       } else {
-        p.append(name, value || "");
+        p.append(
+          name,
+          typeof value === "string" ? value : JSON.stringify(value)
+        );
       }
     }
     return p;

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -32,9 +32,22 @@ describe("withQuery", () => {
     },
     { input: "/?x=1,2,3", query: { y: "1,2,3" }, out: "/?x=1,2,3&y=1,2,3" },
     { input: "http://a.com?v=1", query: { x: 2 }, out: "http://a.com?v=1&x=2" },
-    { input: "/", query: { json: "{\"test\":[\"content\"]}" }, out: "/?json=%7B%22test%22:%5B%22content%22%5D%7D" },
+    {
+      input: "/",
+      query: { json: '{"test":["content"]}' },
+      out: "/?json=%7B%22test%22:%5B%22content%22%5D%7D",
+    },
     { input: "/", query: { param: ["3", ""] }, out: "/?param=3&param=" },
     { input: "/", query: { param: ["", "3"] }, out: "/?param=&param=3" },
+    {
+      input: "/",
+      query: { param: { a: { nested: { object: 123 } } } },
+      out:
+        "/?param=" +
+        encodeURIComponent(
+          JSON.stringify({ a: { nested: { object: 123 } } })
+        ).replace(/%3A/g, ":"),
+    },
   ];
 
   for (const t of tests) {

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -42,11 +42,17 @@ describe("withQuery", () => {
     {
       input: "/",
       query: { param: { a: { nested: { object: 123 } } } },
-      out:
-        "/?param=" +
-        encodeURIComponent(
-          JSON.stringify({ a: { nested: { object: 123 } } })
-        ).replace(/%3A/g, ":"),
+      out: "/?param=%7B%22a%22:%7B%22nested%22:%7B%22object%22:123%7D%7D%7D",
+    },
+    {
+      input: "/",
+      query: { param: { a: [{ obj: 1 }, { obj: 2 }] } },
+      out: "/?param=%7B%22a%22:%5B%7B%22obj%22:1%7D,%7B%22obj%22:2%7D%5D%7D", // {"a":[{"obj":1},{"obj":2}]}
+    },
+    {
+      input: "/",
+      query: { param: { a: [{ obj: [1, 2, 3] }] } },
+      out: "/?param=%7B%22a%22:%5B%7B%22obj%22:%5B1,2,3%5D%7D%5D%7D", // {"a":[{"obj":[1,2,3]}]}
     },
   ];
 


### PR DESCRIPTION
resolves #41 resolves #62
rework and closes #72

Currently (same as URLSearchParams) if input is not string/number, we encode it to something like `foo=%5Bobject+Object%5D` which is useless! 

There is no standard spec, however this PR solves it with simplest method of using `JSON.stringify`