### PR TITLE
feat(hasProtocol): strict mode support

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -20,7 +20,7 @@ export interface ParsedHost {
 }
 
 export function parseURL(input = "", defaultProto?: string): ParsedURL {
-  if (!hasProtocol(input, true)) {
+  if (!hasProtocol(input, { acceptRelative: true })) {
     return defaultProto ? parseURL(defaultProto + input) : parsePath(input);
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,7 +7,7 @@ export function isRelative(inputString: string) {
   return ["./", "../"].some((string_) => inputString.startsWith(string_));
 }
 
-const PROTOCOL_STRICT_REGEX = /^\w{2,}:([/\\]{2})/;
+const PROTOCOL_STRICT_REGEX = /^\w{2,}:([/\\]{1,2})/;
 const PROTOCOL_REGEX = /^\w{2,}:([/\\]{2})?/;
 const PROTOCOL_RELATIVE_REGEX = /^[/\\]{2}[^/\\]+/;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,7 +13,7 @@ const PROTOCOL_RELATIVE_REGEX = /^[/\\]{2}[^/\\]+/;
 
 /**
  * @deprecated
- * Same as { hasProtocol(inputString, { acceptProtocolRelative: true })
+ * Same as { hasProtocol(inputString, { acceptRelative: true })
  */
 export type HasProtocolLegacyOptioon = boolean;
 export type HasProtocolOptions = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,16 +7,33 @@ export function isRelative(inputString: string) {
   return ["./", "../"].some((string_) => inputString.startsWith(string_));
 }
 
+const PROTOCOL_STRICT_REGEX = /^\w{2,}:([/\\]{2})/;
 const PROTOCOL_REGEX = /^\w{2,}:([/\\]{2})?/;
 const PROTOCOL_RELATIVE_REGEX = /^[/\\]{2}[^/\\]+/;
 
+/**
+ * @deprecated
+ * Same as { hasProtocol(inputString, { acceptProtocolRelative: true })
+ */
+export type HasProtocolLegacyOptioon = boolean;
+export type HasProtocolOptions = {
+  acceptRelative?: boolean;
+  strict?: boolean;
+};
+
 export function hasProtocol(
   inputString: string,
-  acceptProtocolRelative = false
+  opts: HasProtocolLegacyOptioon | HasProtocolOptions = {}
 ): boolean {
+  if (typeof opts === "boolean") {
+    opts = { acceptRelative: opts };
+  }
+  if (opts.strict) {
+    return PROTOCOL_STRICT_REGEX.test(inputString);
+  }
   return (
     PROTOCOL_REGEX.test(inputString) ||
-    (acceptProtocolRelative && PROTOCOL_RELATIVE_REGEX.test(inputString))
+    (opts.acceptRelative ? PROTOCOL_RELATIVE_REGEX.test(inputString) : false)
   );
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,7 +18,7 @@ export interface HasProtocolOptions {
 export function hasProtocol(
   inputString: string,
   opts?: HasProtocolOptions
-): boolean
+): boolean;
 /**
  * @deprecated
  * Same as { hasProtocol(inputString, { acceptRelative: true })
@@ -26,7 +26,7 @@ export function hasProtocol(
 export function hasProtocol(
   inputString: string,
   acceptRelative: boolean
-): boolean
+): boolean;
 export function hasProtocol(
   inputString: string,
   opts: boolean | HasProtocolOptions = {}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,19 +11,25 @@ const PROTOCOL_STRICT_REGEX = /^\w{2,}:([/\\]{1,2})/;
 const PROTOCOL_REGEX = /^\w{2,}:([/\\]{2})?/;
 const PROTOCOL_RELATIVE_REGEX = /^[/\\]{2}[^/\\]+/;
 
+export interface HasProtocolOptions {
+  acceptRelative?: boolean;
+  strict?: boolean;
+}
+export function hasProtocol(
+  inputString: string,
+  opts?: HasProtocolOptions
+): boolean
 /**
  * @deprecated
  * Same as { hasProtocol(inputString, { acceptRelative: true })
  */
-export type HasProtocolLegacyOption = boolean;
-export type HasProtocolOptions = {
-  acceptRelative?: boolean;
-  strict?: boolean;
-};
-
 export function hasProtocol(
   inputString: string,
-  opts: HasProtocolLegacyOption | HasProtocolOptions = {}
+  acceptRelative: boolean
+): boolean
+export function hasProtocol(
+  inputString: string,
+  opts: boolean | HasProtocolOptions = {}
 ): boolean {
   if (typeof opts === "boolean") {
     opts = { acceptRelative: opts };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,7 +15,7 @@ const PROTOCOL_RELATIVE_REGEX = /^[/\\]{2}[^/\\]+/;
  * @deprecated
  * Same as { hasProtocol(inputString, { acceptRelative: true })
  */
-export type HasProtocolLegacyOptioon = boolean;
+export type HasProtocolLegacyOption = boolean;
 export type HasProtocolOptions = {
   acceptRelative?: boolean;
   strict?: boolean;
@@ -23,7 +23,7 @@ export type HasProtocolOptions = {
 
 export function hasProtocol(
   inputString: string,
-  opts: HasProtocolLegacyOptioon | HasProtocolOptions = {}
+  opts: HasProtocolLegacyOption | HasProtocolOptions = {}
 ): boolean {
   if (typeof opts === "boolean") {
     opts = { acceptRelative: opts };

--- a/test/utilities.test.ts
+++ b/test/utilities.test.ts
@@ -20,6 +20,7 @@ describe("hasProtocol", () => {
     { input: "/test", out: [false, false, false] },
 
     // Has protocol (strict)
+    { input: "custom:/", out: [true, true, true] },
     { input: "https://", out: [true, true, true] },
     { input: "https://test.com", out: [true, true, true] },
     { input: "file:///home/user", out: [true, true, true] },

--- a/test/utilities.test.ts
+++ b/test/utilities.test.ts
@@ -13,26 +13,37 @@ import {
 
 describe("hasProtocol", () => {
   const tests = [
-    { input: "//", out: [false, false] },
-    { input: "///", out: [false, false] },
-    { input: "//test.com", out: [true, false] },
-    { input: "https://", out: [true, true] },
-    { input: "https://test.com", out: [true, true] },
-    { input: "/test", out: [false, false] },
-    { input: "C:/test", out: [false, false] },
-    { input: "file:///home/user", out: [true, true] },
-    { input: "tel:", out: [true, true] },
-    { input: "tel:123456", out: [true, true] },
-    { input: "mailto:support@example.com", out: [true, true] },
-    { input: "/\\localhost//", out: [true, false] },
-    { input: "https:\\/foo.com", out: [true, true] },
+    // No protocol
+    { input: "//", out: [false, false, false] },
+    { input: "///", out: [false, false, false] },
+    { input: "C:/test", out: [false, false, false] },
+    { input: "/test", out: [false, false, false] },
+
+    // Has protocol (strict)
+    { input: "https://", out: [true, true, true] },
+    { input: "https://test.com", out: [true, true, true] },
+    { input: "file:///home/user", out: [true, true, true] },
+    { input: "https:\\/foo.com", out: [true, true, true] },
+
+    // Has protocol (non strict)
+    { input: "tel:", out: [true, false, true] },
+    { input: "tel:123456", out: [true, false, true] },
+    { input: "mailto:support@example.com", out: [true, false, true] },
+
+    // Relative
+    { input: "//test.com", out: [false, false, true] },
+    { input: "/\\localhost//", out: [false, false, true] },
   ];
 
   for (const t of tests) {
     test(t.input.toString(), () => {
-      const [withAcceptRelative, withoutAcceptRelative] = t.out;
+      const [withDefault, withStrict, withAcceptRelative] = t.out;
+      expect(hasProtocol(t.input)).toBe(withDefault);
+      expect(hasProtocol(t.input, { strict: true })).toBe(withStrict);
+      expect(hasProtocol(t.input, { acceptRelative: true })).toBe(
+        withAcceptRelative
+      );
       expect(hasProtocol(t.input, true)).toBe(withAcceptRelative);
-      expect(hasProtocol(t.input)).toBe(withoutAcceptRelative);
     });
   }
 });


### PR DESCRIPTION
Resolves #70

Using `hasProtocol('..', { strict: true })` we require that protocol url ends with at least one slash.