### PR TITLE
feat: generic types for `getQuery` util.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode
+.idea
 node_modules
 *.log
 .DS_Store

--- a/src/query.ts
+++ b/src/query.ts
@@ -10,11 +10,12 @@ export type QueryValue =
   | number
   | undefined
   | null
+  | boolean
   | Record<string, any>;
 export type QueryObject = Record<string, QueryValue | QueryValue[]>;
 
-export function parseQuery(parametersString = ""): QueryObject {
-  const object: QueryObject = {};
+export function parseQuery<T = QueryObject>(parametersString = ""): T {
+  const object = {} as T;
   if (parametersString[0] === "?") {
     parametersString = parametersString.slice(1);
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -126,8 +126,8 @@ export function withQuery(input: string, query: QueryObject): string {
   return stringifyParsedURL(parsed);
 }
 
-export function getQuery(input: string): QueryObject {
-  return parseQuery(parseURL(input).search);
+export function getQuery<T = QueryObject>(input: string): T {
+  return parseQuery<T>(parseURL(input).search);
 }
 
 export function isEmptyURL(url: string) {


### PR DESCRIPTION
I made very simple generic types for getQuery, maybe something different should be done, let me know.

Also fixed `QueryValue` to be compatible with `boolean` too, which resolved type errors in `query.test.ts`