### PR TITLE
Add declaration map for source code viewing

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "ESNext",
     "module": "ESNext",
+    "declarationMap": true",
     "moduleResolution": "Node",
     "esModuleInterop": true
   },


### PR DESCRIPTION
While looking at declaration for `withoutTrailingSlash` because it was undocumented, it lead me to the `d.ts` file. This does not help at all for DX

https://www.typescriptlang.org/tsconfig#declarationMap