### PR TITLE
fix: `parseQuery` should return a string types

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -13,8 +13,8 @@ export type QueryValue =
   | Record<string, any>;
 export type QueryObject = Record<string, QueryValue | QueryValue[]>;
 
-export function parseQuery(parametersString = ""): QueryObject {
-  const object: QueryObject = {};
+export function parseQuery(parametersString = "") {
+  const object: Record<string, string | string[]> = {};
   if (parametersString[0] === "?") {
     parametersString = parametersString.slice(1);
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -126,7 +126,7 @@ export function withQuery(input: string, query: QueryObject): string {
   return stringifyParsedURL(parsed);
 }
 
-export function getQuery(input: string): QueryObject {
+export function getQuery(input: string) {
   return parseQuery(parseURL(input).search);
 }
 


### PR DESCRIPTION
[    const value = decodeQueryValue(s[2] || "");](https://github.com/unjs/ufo/blob/ffff78843f63a99366a3ef99540111970a21c3a1/src/query.ts#L30)

Based on the code, `parseQuery` function will always return  a `Record<string, string | string[]>` type