### PR TITLE
fix(parseQuery): decode space in query keys

### DIFF
--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -126,6 +126,16 @@ export function decodePath(text: string): string {
 }
 
 /**
+ * Decode query key (consistent with encodeQueryKey for plus encoding).
+ * Created different method for decoding key to avoid future changes on value encode/decode.
+ * @param text - string to decode
+ * @returns decoded string
+ */
+export function decodeQueryKey(text: string): string {
+  return decode(text.replace(PLUS_RE, " "));
+}
+
+/**
  * Decode query value (consistent with encodeQueryValue for plus encoding).
  *
  * @param text - string to decode

--- a/src/query.ts
+++ b/src/query.ts
@@ -1,5 +1,5 @@
 import {
-  decode,
+  decodeQueryKey,
   decodeQueryValue,
   encodeQueryKey,
   encodeQueryValue,
@@ -23,7 +23,7 @@ export function parseQuery(parametersString = ""): QueryObject {
     if (s.length < 2) {
       continue;
     }
-    const key = decode(s[1]);
+    const key = decodeQueryKey(s[1]);
     if (key === "__proto__" || key === "constructor") {
       continue;
     }

--- a/test/encoding.test.ts
+++ b/test/encoding.test.ts
@@ -7,6 +7,7 @@ import {
   encodePath,
   encodeParam,
   decode,
+  decodeQueryKey,
 } from "../src/";
 
 describe("encode", () => {
@@ -186,6 +187,23 @@ describe("decode", () => {
   for (const t of tests) {
     test(t.input.toString(), () => {
       expect(decode(t.input.toString())).toStrictEqual(t.out);
+    });
+  }
+});
+
+describe("decodeQueryKey", () => {
+  const tests = [
+    { input: "key", out: "key" },
+    { input: "key%3Dvalue", out: "key=value" },
+    { input: "123", out: "123" },
+    { input: "%3Dvalue", out: "=value" },
+    { input: "key+with+space", out: "key with space" },
+    { input: "key%2bwith%2bplus", out: "key+with+plus" },
+  ];
+
+  for (const t of tests) {
+    test(t.input.toString(), () => {
+      expect(decodeQueryKey(t.input.toString())).toStrictEqual(t.out);
     });
   }
 });

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -27,6 +27,11 @@ describe("withQuery", () => {
     },
     {
       input: "/",
+      query: { 'key with space': "spaced value" },
+      out: "/?key+with+space=spaced+value",
+    },
+    {
+      input: "/",
       query: { str: "&", str2: "%26" },
       out: "/?str=%26&str2=%2526",
     },


### PR DESCRIPTION
Added support to decode query params key properly.

Fixed: https://github.com/unjs/ufo/issues/149

