### PR TITLE
fix(joinURL): fix joinURL doesn't correctly join relative URLs to falsy bases

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
-import { $URL } from "./url";
+import { decode } from "./encoding";
 import { parseURL, stringifyParsedURL } from "./parse";
 import { QueryObject, parseQuery, stringifyQuery } from "./query";
-import { decode } from "./encoding";
+import { $URL } from "./url";
 
 export function isRelative(inputString: string) {
   return ["./", "../"].some((string_) => inputString.startsWith(string_));
@@ -141,8 +141,23 @@ export function isNonEmptyURL(url: string) {
 export function joinURL(base: string, ...input: string[]): string {
   let url = base || "";
 
-  for (const index of input.filter((url) => isNonEmptyURL(url))) {
-    url = url ? withTrailingSlash(url) + withoutLeadingSlash(index) : index;
+  const normalizedInput: string[] = [];
+
+  for (let index = 0; index < input.length; index++) {
+    const previousElement = input[index - 1] || url;
+    let currentElement = input[index];
+
+    if (previousElement) {
+      currentElement = currentElement.replace("./", "");
+    }
+
+    if (isNonEmptyURL(currentElement)) {
+      normalizedInput.push(currentElement);
+    }
+  }
+
+  for (const item of normalizedInput) {
+    url = url ? withTrailingSlash(url) + withoutLeadingSlash(item) : item;
   }
 
   return url;

--- a/test/join.test.ts
+++ b/test/join.test.ts
@@ -12,6 +12,7 @@ describe("joinURL", () => {
     { input: ["/", "/b"], out: "/b" },
     { input: ["a", "b/", "c"], out: "a/b/c" },
     { input: ["a", "b/", "/c"], out: "a/b/c" },
+    { input: ["/", "./"], out: "/" },
   ];
 
   for (const t of tests) {


### PR DESCRIPTION
### 🔗 Linked issue
#35 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves #35 

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
