### PR TITLE
feat: add `isScriptProtocol` util

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,13 +10,10 @@ export function isRelative(inputString: string) {
 const PROTOCOL_STRICT_REGEX = /^\w{2,}:([/\\]{1,2})/;
 const PROTOCOL_REGEX = /^\w{2,}:([/\\]{2})?/;
 const PROTOCOL_RELATIVE_REGEX = /^([/\\]\s*){2,}[^/\\]/;
-const PROTOCOL_SCRIPT_RE = /^(data|javascript|vbscript):$/;
 
 export interface HasProtocolOptions {
   acceptRelative?: boolean;
   strict?: boolean;
-  /** Set to false to return false for script protocols (data:, javascript:, and vbscript:) */
-  script?: boolean;
 }
 export function hasProtocol(
   inputString: string,
@@ -37,9 +34,6 @@ export function hasProtocol(
   if (typeof opts === "boolean") {
     opts = { acceptRelative: opts };
   }
-  if (opts.script === false && PROTOCOL_SCRIPT_RE.test(inputString)) {
-    return false;
-  }
   if (opts.strict) {
     return PROTOCOL_STRICT_REGEX.test(inputString);
   }
@@ -47,6 +41,11 @@ export function hasProtocol(
     PROTOCOL_REGEX.test(inputString) ||
     (opts.acceptRelative ? PROTOCOL_RELATIVE_REGEX.test(inputString) : false)
   );
+}
+
+const PROTOCOL_SCRIPT_RE = /^(data|javascript|vbscript):$/;
+export function isScriptProtocol(protocol?: string) {
+  return !!protocol && PROTOCOL_SCRIPT_RE.test(protocol);
 }
 
 const TRAILING_SLASH_RE = /\/$|\/\?/;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,7 +43,7 @@ export function hasProtocol(
   );
 }
 
-const PROTOCOL_SCRIPT_RE = /^(data|javascript|vbscript):$/;
+const PROTOCOL_SCRIPT_RE = /^(blob|data|javascript|vbscript):$/;
 export function isScriptProtocol(protocol?: string) {
   return !!protocol && PROTOCOL_SCRIPT_RE.test(protocol);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -44,6 +44,7 @@ export function hasProtocol(
 }
 
 const PROTOCOL_SCRIPT_RE = /^(blob|data|javascript|vbscript):$/;
+
 export function isScriptProtocol(protocol?: string) {
   return !!protocol && PROTOCOL_SCRIPT_RE.test(protocol);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,7 +15,8 @@ const PROTOCOL_SCRIPT_RE = /^(data|javascript|vbscript):$/;
 export interface HasProtocolOptions {
   acceptRelative?: boolean;
   strict?: boolean;
-  script?: boolean
+  /** Set to false to return false for script protocols (data:, javascript:, and vbscript:) */
+  script?: boolean;
 }
 export function hasProtocol(
   inputString: string,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,10 +10,12 @@ export function isRelative(inputString: string) {
 const PROTOCOL_STRICT_REGEX = /^\w{2,}:([/\\]{1,2})/;
 const PROTOCOL_REGEX = /^\w{2,}:([/\\]{2})?/;
 const PROTOCOL_RELATIVE_REGEX = /^([/\\]\s*){2,}[^/\\]/;
+const PROTOCOL_SCRIPT_RE = /^(data|javascript|vbscript):$/;
 
 export interface HasProtocolOptions {
   acceptRelative?: boolean;
   strict?: boolean;
+  script?: boolean
 }
 export function hasProtocol(
   inputString: string,
@@ -33,6 +35,9 @@ export function hasProtocol(
 ): boolean {
   if (typeof opts === "boolean") {
     opts = { acceptRelative: opts };
+  }
+  if (opts.script === false && PROTOCOL_SCRIPT_RE.test(inputString)) {
+    return false;
   }
   if (opts.strict) {
     return PROTOCOL_STRICT_REGEX.test(inputString);


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

https://github.com/nuxt/nuxt/pull/22366

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This allows checking for protocol existence with `hasProtocol('https://test.com', { script: false })`, in cases where we want to safely redirect to an external URL.

API thoughts welcome.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
