### PR TITLE
fix(parseURL): handle `data:` and `blob` protocols

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -4,6 +4,7 @@ export interface ParsedURL {
   protocol?: string;
   host?: string;
   auth?: string;
+  href?: string;
   pathname: string;
   hash: string;
   search: string;
@@ -27,6 +28,20 @@ export interface ParsedHost {
  * @returns A parsed URL object.
  */
 export function parseURL(input = "", defaultProto?: string): ParsedURL {
+  const dataMatch = input.match(/^(data|blob):/);
+  if (dataMatch) {
+    const proto = dataMatch[1];
+    return {
+      protocol: proto + ":",
+      pathname: input.slice(proto.length + 1),
+      href: input,
+      auth: "",
+      host: "",
+      search: "",
+      hash: "",
+    };
+  }
+
   if (!hasProtocol(input, { acceptRelative: true })) {
     return defaultProto ? parseURL(defaultProto + input) : parsePath(input);
   }

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -28,12 +28,12 @@ export interface ParsedHost {
  * @returns A parsed URL object.
  */
 export function parseURL(input = "", defaultProto?: string): ParsedURL {
-  const dataMatch = input.match(/^(data|blob):/);
+  const dataMatch = input.match(/^(data:|blob:)/);
   if (dataMatch) {
     const proto = dataMatch[1];
     return {
-      protocol: proto + ":",
-      pathname: input.slice(proto.length + 1),
+      protocol: proto,
+      pathname: input.slice(proto.length),
       href: input,
       auth: "",
       host: "",

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -81,6 +81,30 @@ describe("parseURL", () => {
         hash: "#owo",
       },
     },
+    {
+      input: "data:image/png;base64,aaa//bbbbbb/ccc",
+      out: {
+        protocol: "data:",
+        auth: "",
+        host: "",
+        href: "data:image/png;base64,aaa//bbbbbb/ccc",
+        pathname: "image/png;base64,aaa//bbbbbb/ccc",
+        search: "",
+        hash: "",
+      },
+    },
+    {
+      input: "blob:https://video_url",
+      out: {
+        protocol: "blob:",
+        auth: "",
+        host: "",
+        href: "blob:https://video_url",
+        pathname: "https://video_url",
+        search: "",
+        hash: "",
+      },
+    },
   ];
 
   for (const t of tests) {


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #158

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

As `parseURL` accept an ambegious input (path or URL), we cannot allow all `proto:...` without `proto://` syntax. This PR adds special handler check for `data` and `blob`


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
