### PR TITLE
fix: always encode `=` in query key and values

### DIFF
--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -61,16 +61,17 @@ export function encodeQueryValue(input: QueryValue): string {
       .replace(AMPERSAND_RE, "%26")
       .replace(ENC_BACKTICK_RE, "`")
       .replace(ENC_CARET_RE, "^")
+      .replace(EQUAL_RE, "%3D")
   );
 }
 
 /**
- * Like `encodeQueryValue` but also encodes the `=` character.
+ * Same as `encodeQueryValue`
  *
  * @param text - string to encode
  */
 export function encodeQueryKey(text: string | number): string {
-  return encodeQueryValue(text).replace(EQUAL_RE, "%3D");
+  return encodeQueryValue(text);
 }
 
 /**

--- a/test/encoding.test.ts
+++ b/test/encoding.test.ts
@@ -85,10 +85,10 @@ describe("encodeQueryValue", () => {
   const tests = [
     { input: "hello world", out: "hello+world" },
     { input: "hello+world", out: "hello%2Bworld" },
-    { input: "key=value", out: "key=value" },
+    { input: "key=value", out: "key%3Dvalue" },
     { input: true, out: "true" },
     { input: 42, out: "42" },
-    { input: "a=1&b=2", out: "a=1%26b=2" },
+    { input: "a=1&b=2", out: "a%3D1%26b%3D2" },
     {
       input: ["apple", "banana", "cherry"],
       out: "apple,banana,cherry",

--- a/test/normalize.test.ts
+++ b/test/normalize.test.ts
@@ -30,8 +30,8 @@ describe("normalizeURL", () => {
     "/http:/": "/http:/",
     "http://[2001:db8:85a3:8d3:1319:8a2e:370:7348]/":
       "http://[2001:db8:85a3:8d3:1319:8a2e:370:7348]/",
-    "http://localhost/?redirect=http://google.com?q=test":
-      "http://localhost/?redirect=http://google.com?q=test",
+    "http://localhost/?redirect=http://google.com?q%3Dtest":
+      "http://localhost/?redirect=http://google.com?q%3Dtest",
     "http://localhost/?email=some+v1@email.com":
       "http://localhost/?email=some+v1@email.com",
     "http://localhost/?email=some%2Bv1%40email.com":


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

resolves #162

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
URL ponyfill output is different from encoding query value `=` with `new URL`

- `new URL`
```js
const url = new URL('https://unjs.io/')
url.searchParams.set('foo', 'a=1&b=1')

console.log(url.toString()) // output -> `https://unjs.io/?foo=a%3D1%26b%3D1`
```

- `withQuery`
```js
import { withQuery } from 'ufo'

const url = withQuery('https://unjs.io/', { foo: 'a=1&b=1' })

console.log(url) // output -> `https://unjs.io/?foo=a=1%26b=1`
```

---

https://url.spec.whatwg.org/#concept-urlencoded-serializer
> Let name be the result of running [percent-encode after encoding](https://url.spec.whatwg.org/#string-percent-encode-after-encoding) with encoding, tuple’s name, the [application/x-www-form-urlencoded percent-encode set](https://url.spec.whatwg.org/#application-x-www-form-urlencoded-percent-encode-set), and true.

> Let value be the result of running [percent-encode after encoding](https://url.spec.whatwg.org/#string-percent-encode-after-encoding) with encoding, tuple’s value, the [application/x-www-form-urlencoded percent-encode set](https://url.spec.whatwg.org/#application-x-www-form-urlencoded-percent-encode-set), and true.

From the URL serializing document, `encodeQueryValue` should be same as `encodeQueryKey` 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
