### PR TITLE
fix(parseURL, hasProtocol, isScriptProtocol): ignore leading whitespaces

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -47,7 +47,8 @@ export function parseURL(input = "", defaultProto?: string): ParsedURL {
   }
 
   const [protocol = "", auth, hostAndPath = ""] = (
-    input.replace(/\\/g, "/").match(/([\s\w\0+.-]{2,}:)?\/\/([^/@]+@)?(.*)/) || []
+    input.replace(/\\/g, "/").match(/([\s\w\0+.-]{2,}:)?\/\/([^/@]+@)?(.*)/) ||
+    []
   ).splice(1);
   const [host = "", path = ""] = (
     hostAndPath.match(/([^#/?]*)(.*)?/) || []

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -28,7 +28,7 @@ export interface ParsedHost {
  * @returns A parsed URL object.
  */
 export function parseURL(input = "", defaultProto?: string): ParsedURL {
-  const dataMatch = input.match(/^blob:|data:|javascript:|vbscript:/);
+  const dataMatch = input.match(/^(?:blob:|data:|javascript:|vbscript:)/);
   if (dataMatch) {
     const proto = dataMatch[0];
     return {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -28,7 +28,7 @@ export interface ParsedHost {
  * @returns A parsed URL object.
  */
 export function parseURL(input = "", defaultProto?: string): ParsedURL {
-  const dataMatch = input.match(/^(?:blob|data|javascript|vbscript):/);
+  const dataMatch = input.match(/^blob:|data:|javascript:|vbscript:/);
   if (dataMatch) {
     const proto = dataMatch[0];
     return {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -29,14 +29,14 @@ export interface ParsedHost {
  */
 export function parseURL(input = "", defaultProto?: string): ParsedURL {
   const _specialProtoMatch = input.match(
-    /^(?:blob:|data:|javascript:|vbscript:)/
+    /^[\s\0]*(blob:|data:|javascript:|vbscript:)(.*)/
   );
   if (_specialProtoMatch) {
-    const proto = _specialProtoMatch[0];
+    const [, _proto, _pathname = ""] = _specialProtoMatch;
     return {
-      protocol: proto,
-      pathname: input.slice(proto.length),
-      href: input,
+      protocol: _proto,
+      pathname: _pathname,
+      href: _proto + _pathname,
       auth: "",
       host: "",
       search: "",

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -48,14 +48,11 @@ export function parseURL(input = "", defaultProto?: string): ParsedURL {
     return defaultProto ? parseURL(defaultProto + input) : parsePath(input);
   }
 
-  const [protocol = "", auth, hostAndPath = ""] = (
+  const [, protocol = "", auth, hostAndPath = ""] =
     input
       .replace(/\\/g, "/")
-      .match(/^[\s\0]*([\w+.-]{2,}:)?\/\/([^/@]+@)?(.*)/) || []
-  ).splice(1);
-  const [host = "", path = ""] = (
-    hostAndPath.match(/([^#/?]*)(.*)?/) || []
-  ).splice(1);
+      .match(/^[\s\0]*([\w+.-]{2,}:)?\/\/([^/@]+@)?(.*)/) || [];
+  const [, host = "", path = ""] = hostAndPath.match(/([^#/?]*)(.*)?/) || [];
   const { pathname, search, hash } = parsePath(
     path.replace(/\/(?=[A-Za-z]:)/, "")
   );

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -28,7 +28,7 @@ export interface ParsedHost {
  * @returns A parsed URL object.
  */
 export function parseURL(input = "", defaultProto?: string): ParsedURL {
-  const dataMatch = input.match(/^(blob|data|javascript|vbscript):/);
+  const dataMatch = input.match(/^(?:blob|data|javascript|vbscript):/);
   if (dataMatch) {
     const proto = dataMatch[0];
     return {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -28,9 +28,9 @@ export interface ParsedHost {
  * @returns A parsed URL object.
  */
 export function parseURL(input = "", defaultProto?: string): ParsedURL {
-  const dataMatch = input.match(/^(?:blob:|data:|javascript:|vbscript:)/);
-  if (dataMatch) {
-    const proto = dataMatch[0];
+  const _specialProtoMatch = input.match(/^(?:blob:|data:|javascript:|vbscript:)/);
+  if (_specialProtoMatch) {
+    const proto = _specialProtoMatch[0];
     return {
       protocol: proto,
       pathname: input.slice(proto.length),

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -47,7 +47,7 @@ export function parseURL(input = "", defaultProto?: string): ParsedURL {
   }
 
   const [protocol = "", auth, hostAndPath = ""] = (
-    input.replace(/\\/g, "/").match(/([^/:]+:)?\/\/([^/@]+@)?(.*)/) || []
+    input.replace(/\\/g, "/").match(/([\s\w\0+.-]{2,}:)?\/\/([^/@]+@)?(.*)/) || []
   ).splice(1);
   const [host = "", path = ""] = (
     hostAndPath.match(/([^#/?]*)(.*)?/) || []

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -28,9 +28,9 @@ export interface ParsedHost {
  * @returns A parsed URL object.
  */
 export function parseURL(input = "", defaultProto?: string): ParsedURL {
-  const dataMatch = input.match(/^(data:|blob:)/);
+  const dataMatch = input.match(/^(blob|data|javascript|vbscript):/);
   if (dataMatch) {
-    const proto = dataMatch[1];
+    const proto = dataMatch[0];
     return {
       protocol: proto,
       pathname: input.slice(proto.length),

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -28,7 +28,9 @@ export interface ParsedHost {
  * @returns A parsed URL object.
  */
 export function parseURL(input = "", defaultProto?: string): ParsedURL {
-  const _specialProtoMatch = input.match(/^(?:blob:|data:|javascript:|vbscript:)/);
+  const _specialProtoMatch = input.match(
+    /^(?:blob:|data:|javascript:|vbscript:)/
+  );
   if (_specialProtoMatch) {
     const proto = _specialProtoMatch[0];
     return {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -49,8 +49,9 @@ export function parseURL(input = "", defaultProto?: string): ParsedURL {
   }
 
   const [protocol = "", auth, hostAndPath = ""] = (
-    input.replace(/\\/g, "/").match(/([\s\w\0+.-]{2,}:)?\/\/([^/@]+@)?(.*)/) ||
-    []
+    input
+      .replace(/\\/g, "/")
+      .match(/^[\s\0]*([\w+.-]{2,}:)?\/\/([^/@]+@)?(.*)/) || []
   ).splice(1);
   const [host = "", path = ""] = (
     hostAndPath.match(/([^#/?]*)(.*)?/) || []

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,8 +7,8 @@ export function isRelative(inputString: string) {
   return ["./", "../"].some((string_) => inputString.startsWith(string_));
 }
 
-const PROTOCOL_STRICT_REGEX = /^\w{2,}:([/\\]{1,2})/;
-const PROTOCOL_REGEX = /^\w{2,}:([/\\]{2})?/;
+const PROTOCOL_STRICT_REGEX = /^[\s\w\0]{2,}:([/\\]{1,2})/;
+const PROTOCOL_REGEX = /^[\s\w\0]{2,}:([/\\]{2})?/;
 const PROTOCOL_RELATIVE_REGEX = /^([/\\]\s*){2,}[^/\\]/;
 
 export interface HasProtocolOptions {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,7 +43,7 @@ export function hasProtocol(
   );
 }
 
-const PROTOCOL_SCRIPT_RE = /^(blob|data|javascript|vbscript):$/;
+const PROTOCOL_SCRIPT_RE = /^[\s\0]*(blob|data|javascript|vbscript):$/;
 
 export function isScriptProtocol(protocol?: string) {
   return !!protocol && PROTOCOL_SCRIPT_RE.test(protocol);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,8 +7,8 @@ export function isRelative(inputString: string) {
   return ["./", "../"].some((string_) => inputString.startsWith(string_));
 }
 
-const PROTOCOL_STRICT_REGEX = /^[\s\w\0]{2,}:([/\\]{1,2})/;
-const PROTOCOL_REGEX = /^[\s\w\0]{2,}:([/\\]{2})?/;
+const PROTOCOL_STRICT_REGEX = /^[\s\w\0+.-]{2,}:([/\\]{1,2})/;
+const PROTOCOL_REGEX = /^[\s\w\0+.-]{2,}:([/\\]{2})?/;
 const PROTOCOL_RELATIVE_REGEX = /^([/\\]\s*){2,}[^/\\]/;
 
 export interface HasProtocolOptions {

--- a/test/normalize.test.ts
+++ b/test/normalize.test.ts
@@ -41,7 +41,7 @@ describe("normalizeURL", () => {
     "http://localhost/abc/deg%2f%3f%26?email=some+v1@email.com&foo=bar":
       "http://localhost/abc/deg%2F%3F%26?email=some+v1@email.com&foo=bar",
     "http://example.com/foo\\bar": "http://example.com/foo/bar",
-    "\0http://google.com": "http://google.com"
+    "\0http://google.com": "http://google.com",
   };
 
   const validURLS = [

--- a/test/normalize.test.ts
+++ b/test/normalize.test.ts
@@ -41,6 +41,7 @@ describe("normalizeURL", () => {
     "http://localhost/abc/deg%2f%3f%26?email=some+v1@email.com&foo=bar":
       "http://localhost/abc/deg%2F%3F%26?email=some+v1@email.com&foo=bar",
     "http://example.com/foo\\bar": "http://example.com/foo/bar",
+    "\0http://google.com": "http://google.com"
   };
 
   const validURLS = [

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -71,6 +71,18 @@ describe("parseURL", () => {
       },
     },
     {
+      input: "javascript:alert('hello')",
+      out: {
+        protocol: "javascript:",
+        auth: "",
+        host: "",
+        href: "javascript:alert('hello')",
+        pathname: "alert('hello')",
+        search: "",
+        hash: "",
+      },
+    },
+    {
       input: "https://domain.test:3000#owo",
       out: {
         protocol: "https:",

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -128,6 +128,18 @@ describe("parseURL", () => {
         hash: "",
       },
     },
+    {
+      input: "\0javascript:alert('hello')",
+      out: {
+        protocol: "javascript:",
+        auth: "",
+        host: "",
+        href: "javascript:alert('hello')",
+        pathname: "alert('hello')",
+        search: "",
+        hash: "",
+      },
+    },
   ];
 
   for (const t of tests) {

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -118,14 +118,14 @@ describe("parseURL", () => {
       },
     },
     {
-      input: "\0https://domain.test:3000#owo",
+      input: "\0https://invalid.com",
       out: {
         protocol: "https:",
         auth: "",
-        host: "domain.test:3000",
+        host: "invalid.com",
         pathname: "",
         search: "",
-        hash: "#owo",
+        hash: "",
       },
     },
   ];

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -117,6 +117,17 @@ describe("parseURL", () => {
         hash: "",
       },
     },
+    {
+      input: "\0https://domain.test:3000#owo",
+      out: {
+        protocol: "https:",
+        auth: "",
+        host: "domain.test:3000",
+        pathname: "",
+        search: "",
+        hash: "#owo",
+      },
+    },
   ];
 
   for (const t of tests) {

--- a/test/utilities.test.ts
+++ b/test/utilities.test.ts
@@ -31,6 +31,7 @@ describe("hasProtocol", () => {
     { input: "javascript:alert(true)", out: [true, false, true] },
     { input: " javascript:alert(true)", out: [true, false, true] },
     { input: "\0javascript:alert(true)", out: [true, false, true] },
+    { input: "\0https://", out: [true, true, true] },
     { input: "tel:123456", out: [true, false, true] },
     { input: "mailto:support@example.com", out: [true, false, true] },
 

--- a/test/utilities.test.ts
+++ b/test/utilities.test.ts
@@ -9,6 +9,7 @@ import {
   withHttps,
   withoutProtocol,
   withProtocol,
+  isScriptProtocol,
 } from "../src";
 
 describe("hasProtocol", () => {
@@ -52,6 +53,21 @@ describe("hasProtocol", () => {
         withAcceptRelative
       );
       expect(hasProtocol(t.input, true)).toBe(withAcceptRelative);
+    });
+  }
+});
+
+describe("isScriptProtocol", () => {
+  const tests = [
+    { input: "blob:", out: true },
+    { input: "data:", out: true },
+    { input: "javascript:", out: true },
+    { input: "vbscript:", out: true },
+    { input: "\0vbscript:", out: true },
+  ];
+  for (const t of tests) {
+    test(t.input.toString(), () => {
+      expect(isScriptProtocol(t.input)).toBe(t.out);
     });
   }
 });

--- a/test/utilities.test.ts
+++ b/test/utilities.test.ts
@@ -28,6 +28,9 @@ describe("hasProtocol", () => {
 
     // Has protocol (non strict)
     { input: "tel:", out: [true, false, true] },
+    { input: "javascript:alert(true)", out: [true, false, true] },
+    { input: " javascript:alert(true)", out: [true, false, true] },
+    { input: "\0javascript:alert(true)", out: [true, false, true] },
     { input: "tel:123456", out: [true, false, true] },
     { input: "mailto:support@example.com", out: [true, false, true] },
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

A couple of linked fixes with parsing protocols in URLs: https://url.spec.whatwg.org/#scheme-state

Thanks to @OhB00.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
