### PR TITLE
fix: test script protocols insensitively

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,7 +43,7 @@ export function hasProtocol(
   );
 }
 
-const PROTOCOL_SCRIPT_RE = /^[\s\0]*(blob|data|javascript|vbscript):$/;
+const PROTOCOL_SCRIPT_RE = /^[\s\0]*(blob|data|javascript|vbscript):$/i;
 
 export function isScriptProtocol(protocol?: string) {
   return !!protocol && PROTOCOL_SCRIPT_RE.test(protocol);

--- a/test/utilities.test.ts
+++ b/test/utilities.test.ts
@@ -62,6 +62,7 @@ describe("isScriptProtocol", () => {
     { input: "blob:", out: true },
     { input: "data:", out: true },
     { input: "javascript:", out: true },
+    { input: "javaScript:", out: true },
     { input: "vbscript:", out: true },
     { input: "\0vbscript:", out: true },
   ];


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This addresses an issue where something like `'javaScript:alert(document.domain)'` would not register as a script protocol owing to case sensitivity.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
