### PR TITLE
feat: decouple resolveUrl from URL

### DIFF
--- a/test/resolve.test.ts
+++ b/test/resolve.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest";
 import { resolveURL } from "../src";
 
 describe("resolveURL", () => {
-  const tests = [
+  test.each([
     { input: [], out: "" },
     { input: ["/"], out: "/" },
     { input: ["/a"], out: "/a" },
@@ -12,13 +12,9 @@ describe("resolveURL", () => {
     { input: ["/a?foo=bar#123", "b/", "c/"], out: "/a/b/c/?foo=bar#123" },
     { input: ["http://foo.com", "a"], out: "http://foo.com/a" },
     { input: ["a?x=1", "b?y=2&y=3&z=4"], out: "a/b?x=1&y=2&y=3&z=4" },
-  ];
-
-  for (const t of tests) {
-    test(t.input.toString(), () => {
-      expect(resolveURL(...t.input)).toBe(t.out);
-    });
-  }
+  ])("$input -> $out", (t) => {
+    expect(resolveURL(...t.input)).toBe(t.out);
+  });
 
   test("invalid URL (null)", () => {
     // eslint-disable-next-line unicorn/no-null


### PR DESCRIPTION
### 🔗 Linked issue
#36

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Using the utils to resolve the url but not using URL contructor

Resolves https://github.com/unjs/ufo/issues/36

We continue need to document the $URL 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
