### PR TITLE
refactor(joinURL): rewrite with clear syntax and relative `../` support

### DIFF
--- a/test/base.test.ts
+++ b/test/base.test.ts
@@ -4,8 +4,8 @@ import { withBase, withoutBase } from "../src";
 describe("withBase", () => {
   const tests = [
     { base: "/", input: "/", out: "/" },
-    { base: "/foo", input: "/", out: "/foo" },
-    { base: "/foo/", input: "/", out: "/foo" },
+    { base: "/foo", input: "", out: "/foo" },
+    { base: "/foo/", input: "/", out: "/foo/" },
     { base: "/foo", input: "/bar", out: "/foo/bar" },
     { base: "/base/", input: "/base", out: "/base" },
     { base: "/base", input: "/base/", out: "/base/" },

--- a/test/join.test.ts
+++ b/test/join.test.ts
@@ -22,13 +22,13 @@ describe("joinURL", () => {
     { input: ["/a", "../b"], out: "/b" },
     { input: ["/a/b/c", "../../d"], out: "/a/d" },
     { input: ["/c", "../../d"], out: "/d" },
-    // { input: ["/c", ".././../d"], out: "../d" },
-    // { input: ["../a", "../b"], out: "../b" },
-    // { input: ["../a", "./../b"], out: "../b" },
-    // { input: ["../a", "./../../b"], out: "b" },
-    // { input: ["../a", "../../../b"], out: "../b" },
-    // { input: ["../a", "../../../../b"], out: "../../b" },
-    // { input: ["../a/", "../b"], out: "../b" },
+    { input: ["/c", ".././../d"], out: "/d" },
+    { input: ["../a", "../b"], out: "b" },
+    { input: ["../a", "./../b"], out: "b" },
+    { input: ["../a", "./../../b"], out: "../b" },
+    { input: ["../a", "../../../b"], out: "../../b" },
+    { input: ["../a", "../../../../b"], out: "../../../b" },
+    { input: ["../a/", "../b"], out: "b" },
   ];
 
   for (const t of tests) {

--- a/test/join.test.ts
+++ b/test/join.test.ts
@@ -5,38 +5,35 @@ describe("joinURL", () => {
   const tests = [
     { input: [], out: "" },
     { input: ["/"], out: "/" },
-    // eslint-disable-next-line unicorn/no-null
-    { input: [null, "./"], out: "./" },
+    { input: [undefined, "./"], out: "./" },
     { input: ["./", "a"], out: "./a" },
     { input: ["./a", "./b"], out: "./a/b" },
     { input: ["/a"], out: "/a" },
     { input: ["a", "b"], out: "a/b" },
     { input: ["/", "/b"], out: "/b" },
-    { input: ["/a", "../b"], out: "/b" },
-    { input: ["../a", "../b"], out: "../b" },
-    { input: ["../a", "./../b"], out: "../b" },
-    { input: ["../a", "./../../b"], out: "b" },
-    { input: ["../a", "../../../b"], out: "../b" },
-    { input: ["../a", "../../../../b"], out: "../../b" },
-    { input: ["../a/", "../b"], out: "../b" },
-    { input: ["/a/b/c", "../../d"], out: "/a/d" },
-    { input: ["/c", "../../d"], out: "../d" },
-    { input: ["/c", ".././../d"], out: "../d" },
     { input: ["a", "b/", "c"], out: "a/b/c" },
     { input: ["a", "b/", "/c"], out: "a/b/c" },
     { input: ["/", "./"], out: "/" },
     { input: ["/", "./foo"], out: "/foo" },
     { input: ["/", "./foo/"], out: "/foo/" },
     { input: ["/", "./foo", "bar"], out: "/foo/bar" },
+
+    // Relative with ../
+    { input: ["/a", "../b"], out: "/b" },
+    { input: ["/a/b/c", "../../d"], out: "/a/d" },
+    { input: ["/c", "../../d"], out: "/d" },
+    // { input: ["/c", ".././../d"], out: "../d" },
+    // { input: ["../a", "../b"], out: "../b" },
+    // { input: ["../a", "./../b"], out: "../b" },
+    // { input: ["../a", "./../../b"], out: "b" },
+    // { input: ["../a", "../../../b"], out: "../b" },
+    // { input: ["../a", "../../../../b"], out: "../../b" },
+    // { input: ["../a/", "../b"], out: "../b" },
   ];
 
   for (const t of tests) {
-    test(JSON.stringify(t.input), () => {
-      expect(joinURL(...t.input)).toBe(t.out);
+    test(`joinURL(${t.input.map((i) => JSON.stringify(i)).join(", ")}) === ${JSON.stringify(t.out)}`, () => {
+      expect(joinURL(...(t.input as string[]))).toBe(t.out);
     });
   }
-
-  test("no arguments", () => {
-    expect(joinURL()).toBe("");
-  });
 });

--- a/test/join.test.ts
+++ b/test/join.test.ts
@@ -23,6 +23,7 @@ describe("joinURL", () => {
     { input: ["/a/b/c", "../../d"], out: "/a/d" },
     { input: ["/c", "../../d"], out: "/d" },
     { input: ["/c", ".././../d"], out: "/d" },
+    { input: ["/c", "../../../d"], out: "../d" },
     { input: ["../a", "../b"], out: "b" },
     { input: ["../a", "./../b"], out: "b" },
     { input: ["../a", "./../../b"], out: "../b" },

--- a/test/join.test.ts
+++ b/test/join.test.ts
@@ -21,9 +21,10 @@ describe("joinURL", () => {
     // Relative with ../
     { input: ["/a", "../b"], out: "/b" },
     { input: ["/a/b/c", "../../d"], out: "/a/d" },
-    { input: ["/c", "../../d"], out: "/d" },
-    { input: ["/c", ".././../d"], out: "/d" },
-    { input: ["/c", "../../../d"], out: "../d" },
+    { input: ["/a", "../../d"], out: "/d" },
+    { input: ["/a", ".././../d"], out: "/d" },
+    { input: ["/a", "../../../d"], out: "../d" },
+    { input: ["/a/b", "../../../d"], out: "/d" },
     { input: ["../a", "../b"], out: "b" },
     { input: ["../a", "./../b"], out: "b" },
     { input: ["../a", "./../../b"], out: "../b" },


### PR DESCRIPTION
As a continuation to #217 (to resolve #37), this PR reimplements `joinURL` utility with more clear syntax and basic support for relative `../` segments


**Behavior change:** For `joinURL` and `withBase`, the trailing slash of base is always respected. It is more of a bug fix.