### PR TITLE
fix: use lookbehind regex only inside `joinRelativeURL`

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,7 +14,6 @@ const PROTOCOL_RELATIVE_REGEX = /^([/\\]\s*){2,}[^/\\]/;
 const PROTOCOL_SCRIPT_RE = /^[\s\0]*(blob|data|javascript|vbscript):$/i;
 const TRAILING_SLASH_RE = /\/$|\/\?|\/#/;
 const JOIN_LEADING_SLASH_RE = /^\.?\//;
-const JOIN_SEGMENT_SPLIT_RE = /(?<!\/)\/(?!\/)/;
 
 /**
  * Check if a path starts with `./` or `../`.
@@ -346,6 +345,9 @@ export function joinURL(base: string, ...input: string[]): string {
  * @group utils
  */
 export function joinRelativeURL(..._input: string[]): string {
+  // Inlined regex to increase browser compatibiltiy for lookbehind (#224)
+  const JOIN_SEGMENT_SPLIT_RE = /(?<!\/)\/(?!\/)/;
+
   const input = _input.filter(Boolean);
 
   const segments: string[] = [];


### PR DESCRIPTION
hotfix to resolve #224

**Note:** Lookbehind syntax is supported in majority of browsers ([caniuse](https://caniuse.com/js-regexp-lookbehind)) and this is a temporary solution until discussing more.