### PR TITLE
fix(joinRelativeURL): avoid lookbehind regex for browser compatibility

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -358,7 +358,7 @@ export function joinRelativeURL(..._input: string[]): string {
     if (!i || i === "/") {
       continue;
     }
-    for (const s of i.split(JOIN_SEGMENT_SPLIT_RE)) {
+    for (const [sindex, s] of i.split(JOIN_SEGMENT_SPLIT_RE).entries()) {
       if (!s || s === ".") {
         continue;
       }
@@ -371,9 +371,8 @@ export function joinRelativeURL(..._input: string[]): string {
         continue;
       }
       // eslint-disable-next-line unicorn/prefer-at
-      const lastSegment = segments[segments.length - 1];
-      if (lastSegment && lastSegment.endsWith(":/")) {
-        segments[segments.length - 1] = lastSegment + "/" + s;
+      if (sindex === 1 && segments[segments.length - 1]?.endsWith(":/")) {
+        segments[segments.length - 1] += "/" + s;
         continue;
       }
       segments.push(s);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -345,9 +345,6 @@ export function joinURL(base: string, ...input: string[]): string {
  * @group utils
  */
 export function joinRelativeURL(..._input: string[]): string {
-  // Inlined regex to increase browser compatibiltiy for lookbehind (#224)
-  const JOIN_SEGMENT_SPLIT_RE = /(?<!\/)\/(?!\/)/;
-
   const input = _input.filter(Boolean);
 
   const segments: string[] = [];
@@ -358,16 +355,20 @@ export function joinRelativeURL(..._input: string[]): string {
     if (!i || i === "/") {
       continue;
     }
-    for (const s of i.split(JOIN_SEGMENT_SPLIT_RE)) {
+    for (const [sindex, s] of i.split("/").entries()) {
       if (!s || s === ".") {
         continue;
       }
       if (s === "..") {
-        if (segments.length === 1 && hasProtocol(segments[0])) {
+        if (segmentsDepth === 1 && segments[0].endsWith(":/")) {
           continue;
         }
         segments.pop();
         segmentsDepth--;
+        continue;
+      }
+      if (sindex === 0 && s.endsWith(":")) {
+        segments.push(s + "/");
         continue;
       }
       segments.push(s);

--- a/test/join.test.ts
+++ b/test/join.test.ts
@@ -20,6 +20,10 @@ const joinURLTests = [
     input: ["https://google.com/", "./foo", "/bar"],
     out: "https://google.com/foo/bar",
   },
+  {
+    input: ["//google.com/", "./foo", "/bar"],
+    out: "//google.com/foo/bar",
+  },
 ] as const;
 
 describe("joinURL", () => {


### PR DESCRIPTION
Related to https://github.com/unjs/ufo/issues/224m, https://github.com/nuxt/nuxt/issues/26393

This PR rewrites `joinRelativeURL` logic to avoid Regex with look behind for safari <= 16.3 compatibility.

