### PR TITLE
fix(parseURL): only normalize windows drive letters with `file://` protocol

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -69,10 +69,15 @@ export function parseURL(input = "", defaultProto?: string): ParsedURL {
     input
       .replace(/\\/g, "/")
       .match(/^[\s\0]*([\w+.-]{2,}:)?\/\/([^/@]+@)?(.*)/) || [];
-  const [, host = "", path = ""] = hostAndPath.match(/([^#/?]*)(.*)?/) || [];
-  const { pathname, search, hash } = parsePath(
-    path.replace(/\/(?=[A-Za-z]:)/, ""),
-  );
+
+  // eslint-disable-next-line prefer-const
+  let [, host = "", path = ""] = hostAndPath.match(/([^#/?]*)(.*)?/) || [];
+
+  if (protocol === "file:") {
+    path = path.replace(/\/(?=[A-Za-z]:)/, "");
+  }
+
+  const { pathname, search, hash } = parsePath(path);
 
   return {
     protocol: protocol.toLowerCase(),

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -60,6 +60,17 @@ describe("parseURL", () => {
       },
     },
     {
+      input: "https://test.com/t:est",
+      out: {
+        auth: "",
+        hash: "",
+        host: "test.com",
+        pathname: "/t:est",
+        protocol: "https:",
+        search: "",
+      },
+    },
+    {
       input: "https://host.name\\@foo.bar/meme3.php?url=http://0.0.0.0/2.svg",
       out: {
         auth: "",


### PR DESCRIPTION
Issue: https://github.com/unjs/ufo/issues/247

URL paths which include a colon as the second character are falsely included in the fix for windows path URLs [here](https://github.com/unjs/ufo/pull/87) resulting in the leading slash being removed.