### PR TITLE
chore: consistent spelling in JSDoc comments & update automd syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ const { normalizeURL, joinURL } = require("ufo");
 import { parseURL } from "https://unpkg.com/ufo/dist/index.mjs";
 ```
 
-<!-- automd:jsdocs src=./src -->
+<!-- automd:jsdocs src=./src defaultGroup=utils -->
 
 ## Encoding Utils
 
@@ -168,6 +168,8 @@ Stringfies and encodes a query object into a query string.
 
 ## Utils
 
+### `$URL()`
+
 ### `cleanDoubleSlashes(input)`
 
 Removes double slashes from the URL.
@@ -195,6 +197,8 @@ getQuery("http://foo.com/foo?test=123&unicode=%E5%A5%BD");
 ### `hasLeadingSlash(input)`
 
 Checks if the input has a leading slash (e.g. `/foo`).
+
+### `hasProtocol(inputString, opts)`
 
 ### `hasTrailingSlash(input, respectQueryAndFragment?)`
 
@@ -374,6 +378,16 @@ withoutHost("http://example.com/foo?q=123#bar")
 
 Removes leading slash from the URL or pathname.
 
+### `withoutProtocol(input)`
+
+Removes the protocol from the input.
+
+**Example:**
+
+```js
+withoutProtocol("http://example.com"); // "example.com"
+```
+
 ### `withoutTrailingSlash(input, respectQueryAndFragment?)`
 
 Removes trailing slash from the URL or pathname.
@@ -420,20 +434,6 @@ If seccond argument is `true`, it will only add the trailing slash if it's not p
 withTrailingSlash("/foo"); // "/foo/"
 
 withTrailingSlash("/path?query=true", true); // "/path/?query=true"
-```
-
-### `$URL()`
-
-### `hasProtocol(inputString, opts)`
-
-### `withoutProtocol(input)`
-
-Removes the protocol from the input.
-
-**Example:**
-
-```js
-withoutProtocol("http://example.com"); // "example.com"
 ```
 
 <!-- /automd -->

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ const { normalizeURL, joinURL } = require("ufo");
 import { parseURL } from "https://unpkg.com/ufo/dist/index.mjs";
 ```
 
-<!-- AUTOMD_START generator="jsdocs" defaultGroup="utils" -->
+<!-- automd:jsdocs src=./src -->
 
 ## Encoding Utils
 
@@ -58,7 +58,7 @@ Decodes query key (consistent with `encodeQueryKey` for plus encoding).
 
 ### `decodeQueryValue(text)`
 
-Decode query value (consistent with encodeQueryValue for plus encoding).
+Decode query value (consistent with `encodeQueryValue` for plus encoding).
 
 ### `encode(text)`
 
@@ -96,7 +96,7 @@ Takes a string of the form `username:password` and returns an object with the us
 
 ### `parseFilename(input)`
 
-Parses a url and returns last segment in path as filename.
+Parses a URL and returns last segment in path as filename.
 
 If `{ strict: true }` is passed as the second argument, it will only return the last segment only if ending with an extension.
 
@@ -160,7 +160,7 @@ If the value is an array, it will be encoded as multiple key-value pairs with th
 
 Parses and decodes a query string into an object.
 
-input can be a query string with or without the leading `?`
+The input can be a query string with or without the leading `?`.
 
 ### `stringifyQuery(query)`
 
@@ -183,7 +183,7 @@ cleanDoubleSlashes("http://example.com/analyze//http://localhost:3000//");
 
 ### `getQuery(input)`
 
-Parses and decods the query object of an input URL into an object.
+Parses and decodes the query object of an input URL into an object.
 
 **Example:**
 
@@ -194,10 +194,7 @@ getQuery("http://foo.com/foo?test=123&unicode=%E5%A5%BD");
 
 ### `hasLeadingSlash(input)`
 
-Checks if the input has a leading slash. (e.g. `/foo`)
-
-### `hasProtocol(inputString, opts)`
-
+Checks if the input has a leading slash (e.g. `/foo`).
 
 ### `hasTrailingSlash(input, respectQueryAndFragment?)`
 
@@ -205,13 +202,14 @@ Checks if the input has a trailing slash.
 
 ### `isEmptyURL(url)`
 
-Checks if the input url is empty or `/`.
+Checks if the input URL is empty or `/`.
 
 ### `isEqual(a, b, options)`
 
 Checks if two paths are equal regardless of encoding, trailing slash, and leading slash differences.
 
 You can make slash check strict by setting `{ trailingSlash: true, leadingSlash: true }` as options.
+
 You can make encoding check strict by setting `{ encoding: true }` as options.
 
 **Example:**
@@ -229,7 +227,7 @@ isEqual("/foo bar", "/foo%20bar", { encoding: true }); // false
 
 ### `isNonEmptyURL(url)`
 
-Checks if the input url is not empty nor `/`.
+Checks if the input URL is not empty nor `/`.
 
 ### `isRelative(inputString)`
 
@@ -277,9 +275,9 @@ joinURL("a", "/b", "/c"); // "a/b/c"
 
 ### `normalizeURL(input)`
 
-Normlizes inputed url:
+Normlizes the input URL:
 
-- Ensures url is properly encoded - Ensures pathname starts with slash - Preserves protocol/host if provided
+- Ensures the URL is properly encoded - Ensures pathname starts with a slash - Preserves protocol/host if provided
 
 **Example:**
 
@@ -310,7 +308,7 @@ If input aleady start with base, it will not be added again.
 
 ### `withFragment(input, hash)`
 
-Add/Replace the fragment section of the URL.
+Adds or replaces the fragment section of the URL.
 
 **Example:**
 
@@ -322,7 +320,7 @@ withFragment("/foo#bar", ""); // "/foo"
 
 ### `withHttp(input)`
 
-Adds or replaces url protocol to `http://`.
+Adds or replaces the URL protocol to `http://`.
 
 **Example:**
 
@@ -332,7 +330,7 @@ withHttp("https://example.com"); // http://example.com
 
 ### `withHttps(input)`
 
-Adds or replaces url protocol to `https://`.
+Adds or replaces the URL protocol to `https://`.
 
 **Example:**
 
@@ -363,7 +361,7 @@ withoutFragment("http://example.com/foo?q=123#bar")
 
 ### `withoutHost(input)`
 
-Removes the host from the URL preserving everything else.
+Removes the host from the URL while preserving everything else.
 
 **Example:**
 
@@ -376,21 +374,11 @@ withoutHost("http://example.com/foo?q=123#bar")
 
 Removes leading slash from the URL or pathname.
 
-### `withoutProtocol(input)`
-
-Removes the protocol from the input.
-
-**Example:**
-
-```js
-withoutProtocol("http://example.com"); // "example.com"
-```
-
 ### `withoutTrailingSlash(input, respectQueryAndFragment?)`
 
 Removes trailing slash from the URL or pathname.
 
-If second argument is true, it will only remove the trailing slash if it's not part of the query or fragment with cost of more expensive operations.
+If second argument is `true`, it will only remove the trailing slash if it's not part of the query or fragment with cost of more expensive operations.
 
 **Example:**
 
@@ -402,7 +390,7 @@ withoutTrailingSlash("/path/?query=true", true); // "/path?query=true"
 
 ### `withProtocol(input, protocol)`
 
-Adds or Replaces protocol of the input URL.
+Adds or replaces protocol of the input URL.
 
 **Example:**
 
@@ -422,7 +410,7 @@ withQuery("/foo?page=a", { token: "secret" }); // "/foo?page=a&token=secret"
 
 ### `withTrailingSlash(input, respectQueryAndFragment?)`
 
-Ensures url ends with a trailing slash.
+Ensures the URL ends with a trailing slash.
 
 If seccond argument is `true`, it will only add the trailing slash if it's not part of the query or fragment with cost of more expensive operation.
 
@@ -434,8 +422,21 @@ withTrailingSlash("/foo"); // "/foo/"
 withTrailingSlash("/path?query=true", true); // "/path/?query=true"
 ```
 
+### `$URL()`
 
-<!-- AUTOMD_END -->
+### `hasProtocol(inputString, opts)`
+
+### `withoutProtocol(input)`
+
+Removes the protocol from the input.
+
+**Example:**
+
+```js
+withoutProtocol("http://example.com"); // "example.com"
+```
+
+<!-- /automd -->
 
 ## License
 

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -155,7 +155,7 @@ export function decodeQueryKey(text: string): string {
 }
 
 /**
- * Decode query value (consistent with encodeQueryValue for plus encoding).
+ * Decode query value (consistent with `encodeQueryValue` for plus encoding).
  *
  * @group encoding_utils
  *

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,6 +1,8 @@
 import { decode } from "./encoding";
 import { hasProtocol } from "./utils";
+
 const protocolRelative = Symbol.for("ufo:protocolRelative");
+
 export interface ParsedURL {
   protocol?: string;
   host?: string;
@@ -180,7 +182,7 @@ const FILENAME_STRICT_REGEX = /\/([^/]+\.[^/]+)$/;
 const FILENAME_REGEX = /\/([^/]+)$/;
 
 /**
- * Parses a url and returns last segment in path as filename.
+ * Parses a URL and returns last segment in path as filename.
  *
  * If `{ strict: true }` is passed as the second argument, it will only return the last segment only if ending with an extension.
  *

--- a/src/query.ts
+++ b/src/query.ts
@@ -76,7 +76,10 @@ export function encodeQueryItem(
 
   if (Array.isArray(value)) {
     return value
-      .map((_value: QueryValue) => `${encodeQueryKey(key)}=${encodeQueryValue(_value)}`)
+      .map(
+        (_value: QueryValue) =>
+          `${encodeQueryKey(key)}=${encodeQueryValue(_value)}`,
+      )
       .join("&");
   }
 

--- a/src/query.ts
+++ b/src/query.ts
@@ -76,7 +76,7 @@ export function encodeQueryItem(
 
   if (Array.isArray(value)) {
     return value
-      .map((_value) => `${encodeQueryKey(key)}=${encodeQueryValue(_value)}`)
+      .map((_value: QueryValue) => `${encodeQueryKey(key)}=${encodeQueryValue(_value)}`)
       .join("&");
   }
 

--- a/src/query.ts
+++ b/src/query.ts
@@ -21,7 +21,7 @@ export type ParsedQuery = Record<string, string | string[]>;
 /**
  * Parses and decodes a query string into an object.
  *
- * input can be a query string with or without the leading `?`
+ * The input can be a query string with or without the leading `?`.
  *
  * @note
  * The `__proto__` and `constructor` keys are ignored to prevent prototype pollution.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -93,7 +93,7 @@ export function hasTrailingSlash(
 /**
  * Removes trailing slash from the URL or pathname.
  *
- * If second argument is true, it will only remove the trailing slash if it's not part of the query or fragment with cost of more expensive operations.
+ * If second argument is `true`, it will only remove the trailing slash if it's not part of the query or fragment with cost of more expensive operations.
  *
  * @example
  *
@@ -130,7 +130,7 @@ export function withoutTrailingSlash(
 }
 
 /**
- * Ensures url ends with a trailing slash.
+ * Ensures the URL ends with a trailing slash.
  *
  * If seccond argument is `true`, it will only add the trailing slash if it's not part of the query or fragment with cost of more expensive operation.
  *
@@ -169,7 +169,7 @@ export function withTrailingSlash(
 }
 
 /**
- * Checks if the input has a leading slash. (e.g. `/foo`)
+ * Checks if the input has a leading slash (e.g. `/foo`).
  *
  * @group utils
  */
@@ -272,7 +272,7 @@ export function withQuery(input: string, query: QueryObject): string {
 }
 
 /**
- * Parses and decods the query object of an input URL into an object.
+ * Parses and decodes the query object of an input URL into an object.
  *
  * @example
  *
@@ -289,7 +289,7 @@ export function getQuery<T extends ParsedQuery = ParsedQuery>(
 }
 
 /**
- * Checks if the input url is empty or `/`.
+ * Checks if the input URL is empty or `/`.
  *
  * @group utils
  */
@@ -298,7 +298,7 @@ export function isEmptyURL(url: string) {
 }
 
 /**
- * Checks if the input url is not empty nor `/`.
+ * Checks if the input URL is not empty nor `/`.
  *
  * @group utils
  */
@@ -404,7 +404,7 @@ export function joinRelativeURL(..._input: string[]): string {
 }
 
 /**
- * Adds or replaces url protocol to `http://`.
+ * Adds or replaces the URL protocol to `http://`.
  *
  * @example
  *
@@ -419,7 +419,7 @@ export function withHttp(input: string): string {
 }
 
 /**
- * Adds or replaces url protocol to `https://`.
+ * Adds or replaces the URL protocol to `https://`.
  *
  * @example
  *
@@ -446,7 +446,7 @@ export function withoutProtocol(input: string): string {
 }
 
 /**
- * Adds or Replaces protocol of the input URL.
+ * Adds or replaces protocol of the input URL.
  *
  * @example
  * ```js
@@ -467,10 +467,10 @@ export function withProtocol(input: string, protocol: string): string {
 }
 
 /**
- * Normlizes inputed url:
+ * Normlizes the input URL:
  *
- * - Ensures url is properly encoded
- * - Ensures pathname starts with slash
+ * - Ensures the URL is properly encoded
+ * - Ensures pathname starts with a slash
  * - Preserves protocol/host if provided
  *
  * @example
@@ -612,7 +612,7 @@ export function isEqual(a: string, b: string, options: CompareURLOptions = {}) {
 }
 
 /**
- * Add/Replace the fragment section of the URL.
+ * Adds or replaces the fragment section of the URL.
  *
  * @example
  *
@@ -650,7 +650,7 @@ export function withoutFragment(input: string): string {
 }
 
 /**
- * Removes the host from the URL preserving everything else.
+ * Removes the host from the URL while preserving everything else.
  *
  * @example
  * ```js


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

Fixes some very minor spelling mistakes and ensures `URL` is always written uppercase.

This is mainly for the JSDoc comment reader/enthusiasts, like me. 😄 

This PR also fixes the `automd` syntax in the README, which was broken and failed to generate the latest docs from the JSDocs.