### PR TITLE
fix(parseFilename): use optional chaining to access `opts.strict`

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Encodes characters that need to be encoded for query values in the query section
 
 Takes a string of the form `username:password` and returns an object with the username and password decoded.
 
-### `parseFilename(input)`
+### `parseFilename(input, opts?: { strict? })`
 
 Parses a URL and returns last segment in path as filename.
 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -181,6 +181,9 @@ export function stringifyParsedURL(parsed: Partial<ParsedURL>): string {
 const FILENAME_STRICT_REGEX = /\/([^/]+\.[^/]+)$/;
 const FILENAME_REGEX = /\/([^/]+)$/;
 
+export interface ParseFilenameOptions {
+  strict?: boolean
+}
 /**
  * Parses a URL and returns last segment in path as filename.
  *
@@ -197,10 +200,13 @@ const FILENAME_REGEX = /\/([^/]+)$/;
  * // Result: undefined
  * parseFilename("/path/to/.hidden-file", { strict: true });
  * ```
+ * 
+ * @param [input] - The URL to parse.
+ * @param [opts]  - Options to use while parsing
  */
-export function parseFilename(input = "", { strict }): string | undefined {
+export function parseFilename(input = "", opts: ParseFilenameOptions = {}): string | undefined {
   const { pathname } = parseURL(input);
-  const matches = strict
+  const matches = opts.strict
     ? pathname.match(FILENAME_STRICT_REGEX)
     : pathname.match(FILENAME_REGEX);
   return matches ? matches[1] : undefined;

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -203,7 +203,7 @@ const FILENAME_REGEX = /\/([^/]+)$/;
  */
 export function parseFilename(
   input = "",
-  opts: { strict },
+  opts?: { strict?: boolean },
 ): string | undefined {
   const { pathname } = parseURL(input);
   const matches = opts?.strict

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -181,9 +181,6 @@ export function stringifyParsedURL(parsed: Partial<ParsedURL>): string {
 const FILENAME_STRICT_REGEX = /\/([^/]+\.[^/]+)$/;
 const FILENAME_REGEX = /\/([^/]+)$/;
 
-export interface ParseFilenameOptions {
-  strict?: boolean
-}
 /**
  * Parses a URL and returns last segment in path as filename.
  *
@@ -200,13 +197,16 @@ export interface ParseFilenameOptions {
  * // Result: undefined
  * parseFilename("/path/to/.hidden-file", { strict: true });
  * ```
- * 
+ *
  * @param [input] - The URL to parse.
  * @param [opts]  - Options to use while parsing
  */
-export function parseFilename(input = "", opts: ParseFilenameOptions = {}): string | undefined {
+export function parseFilename(
+  input = "",
+  opts: { strict },
+): string | undefined {
   const { pathname } = parseURL(input);
-  const matches = opts.strict
+  const matches = opts?.strict
     ? pathname.match(FILENAME_STRICT_REGEX)
     : pathname.match(FILENAME_REGEX);
   return matches ? matches[1] : undefined;

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { parseURL, parseHost, parseFilename } from "../src";
+import { parseURL, parseHost, parseFilename, ParseFilenameOptions } from "../src";
 
 describe("parseURL", () => {
   const tests = [
@@ -197,95 +197,115 @@ describe("parseHost", () => {
 });
 
 describe("parseFilename", () => {
-  const tests = [
-    { input: ["/path/to/filename.ext", false], out: "filename.ext" },
-    { input: ["/path/to/.hidden-file", false], out: ".hidden-file" },
-    { input: ["/path/to/dir/", false], out: undefined },
-    { input: [".", false], out: undefined },
-    { input: ["/", false], out: undefined },
-    { input: ["", false], out: undefined },
+  const tests: { input: { url: string, opts?: ParseFilenameOptions }, out?: string }[] = [
+    { input: { url: "/path/to/filename.ext", opts: undefined }, out: "filename.ext" },
+    { input: { url: "/path/to/.hidden-file", opts: undefined }, out: ".hidden-file" },
+    { input: { url: "/path/to/filename.ext", opts: { strict: false } }, out: "filename.ext" },
+    { input: { url: "/path/to/.hidden-file", opts: { strict: false } }, out: ".hidden-file" },
+    { input: { url: "/path/to/dir/", opts: { strict: false } }, out: undefined },
+    { input: { url: ".", opts: { strict: false } }, out: undefined },
+    { input: { url: "/", opts: { strict: false } }, out: undefined },
+    { input: { url: "", opts: { strict: false } }, out: undefined },
     {
-      input: ["http://example.com/path/to/filename.ext", false],
+      input: { url: "http://example.com/path/to/filename.ext", opts: { strict: false } },
       out: "filename.ext",
     },
     {
-      input: ["http://example.com/path/to/filename.ext?query=true", false],
+      input: { url: "http://example.com/path/to/filename.ext?query=true", opts: { strict: false } },
       out: "filename.ext",
     },
     {
-      input: ["http://example.com/path/to/filename.ext#hash", false],
+      input: { url: "http://example.com/path/to/filename.ext#hash", opts: { strict: false } },
       out: "filename.ext",
     },
     {
-      input: ["http://example.com/path/to/filename.ext?query=true#hash", false],
+      input: { url: "http://example.com/path/to/filename.ext?query=true#hash", opts: { strict: false } },
       out: "filename.ext",
     },
     {
-      input: [
-        "http://example.com/path/to/filename.ext/?query=true#hash",
-        false,
-      ],
+      input: {
+        url:
+          "http://example.com/path/to/filename.ext/?query=true#hash",
+        opts: {
+          strict:
+            false,
+        }
+      },
       out: undefined,
     },
-    { input: ["http://example.com/path/to/dir/", false], out: undefined },
+    { input: { url: "http://example.com/path/to/dir/", opts: { strict: false } }, out: undefined },
     {
-      input: ["http://example.com/path/to/dir/?query=true#hash", false],
+      input: { url: "http://example.com/path/to/dir/?query=true#hash", opts: { strict: false } },
       out: undefined,
     },
-    { input: ["http://example.com/path/to/dir/#hash", false], out: undefined },
-    { input: ["http://example.com", false], out: undefined },
+    { input: { url: "http://example.com/path/to/dir/#hash", opts: { strict: false } }, out: undefined },
+    { input: { url: "http://example.com", opts: { strict: false } }, out: undefined },
     {
-      input: ["ftp://example.com/path/to/filename.ext", false],
+      input: { url: "ftp://example.com/path/to/filename.ext", opts: { strict: false } },
       out: "filename.ext",
     },
-    { input: ["file:///path/to/filename.ext", false], out: "filename.ext" },
-    { input: ["/path/to/filename.ext", true], out: "filename.ext" },
-    { input: ["/path/to/.hidden-file", true], out: undefined },
-    { input: ["/path/to/dir/", true], out: undefined },
-    { input: [".", true], out: undefined },
-    { input: ["/", true], out: undefined },
-    { input: ["", true], out: undefined },
+    { input: { url: "file:///path/to/filename.ext", opts: { strict: false } }, out: "filename.ext" },
+    { input: { url: "/path/to/filename.ext", opts: { strict: true } }, out: "filename.ext" },
+    { input: { url: "/path/to/.hidden-file", opts: { strict: true } }, out: undefined },
+    { input: { url: "/path/to/dir/", opts: { strict: true } }, out: undefined },
+    { input: { url: ".", opts: { strict: true } }, out: undefined },
+    { input: { url: "/", opts: { strict: true } }, out: undefined },
+    { input: { url: "", opts: { strict: true } }, out: undefined },
     {
-      input: ["http://example.com/path/to/filename.ext", true],
-      out: "filename.ext",
-    },
-    {
-      input: ["http://example.com/path/to/filename.ext?query=true", true],
-      out: "filename.ext",
-    },
-    {
-      input: ["http://example.com/path/to/filename.ext#hash", true],
+      input: {
+        url: "http://example.com/path/to/filename.ext", opts: { strict: true }
+      },
       out: "filename.ext",
     },
     {
-      input: ["http://example.com/path/to/filename.ext?query=true#hash", true],
+      input: {
+        url: "http://example.com/path/to/filename.ext?query=true", opts: { strict: true }
+      },
       out: "filename.ext",
     },
     {
-      input: ["http://example.com/path/to/filename.ext/?query=true#hash", true],
+      input: {
+        url: "http://example.com/path/to/filename.ext#hash", opts: { strict: true }
+      },
+      out: "filename.ext",
+    },
+    {
+      input: {
+        url: "http://example.com/path/to/filename.ext?query=true#hash", opts: { strict: true }
+      },
+      out: "filename.ext",
+    },
+    {
+      input: {
+        url: "http://example.com/path/to/filename.ext/?query=true#hash", opts: { strict: true }
+      },
       out: undefined,
     },
-    { input: ["http://example.com/path/to/dir/", true], out: undefined },
+    { input: { url: "http://example.com/path/to/dir/", opts: { strict: true } }, out: undefined },
     {
-      input: ["http://example.com/path/to/dir/?query=true#hash", true],
+      input: {
+        url: "http://example.com/path/to/dir/?query=true#hash", opts: { strict: true }
+      },
       out: undefined,
     },
-    { input: ["http://example.com/path/to/dir/#hash", true], out: undefined },
-    { input: ["http://example.com", true], out: undefined },
+    { input: { url: "http://example.com/path/to/dir/#hash", opts: { strict: true } }, out: undefined },
+    { input: { url: "http://example.com", opts: { strict: true } }, out: undefined },
     {
-      input: ["ftp://example.com/path/to/filename.ext", true],
+      input: {
+        url: "ftp://example.com/path/to/filename.ext", opts: { strict: true }
+      },
       out: "filename.ext",
     },
-    { input: ["file:///path/to/filename.ext", true], out: "filename.ext" },
-    { input: ["/path/to/filename.ext/", true], out: undefined },
-    { input: ["/path/to/dir/../filename.ext", true], out: "filename.ext" },
-    { input: ["/path/to/dir/../filename.ext/", true], out: undefined },
+    { input: { url: "file:///path/to/filename.ext", opts: { strict: true } }, out: "filename.ext" },
+    { input: { url: "/path/to/filename.ext/", opts: { strict: true } }, out: undefined },
+    { input: { url: "/path/to/dir/../filename.ext", opts: { strict: true } }, out: "filename.ext" },
+    { input: { url: "/path/to/dir/../filename.ext/", opts: { strict: true } }, out: undefined },
   ];
 
   for (const t of tests) {
-    test(t.input.toString(), () => {
+    test(t.input.url.toString(), () => {
       expect(
-        parseFilename(t.input[0].toString(), { strict: t.input[1] }),
+        parseFilename(t.input.url.toString(), t.input.opts),
       ).toStrictEqual(t.out);
     });
   }

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { parseURL, parseHost, parseFilename, ParseFilenameOptions } from "../src";
+import { parseURL, parseHost, parseFilename } from "../src";
 
 describe("parseURL", () => {
   const tests = [
@@ -197,115 +197,99 @@ describe("parseHost", () => {
 });
 
 describe("parseFilename", () => {
-  const tests: { input: { url: string, opts?: ParseFilenameOptions }, out?: string }[] = [
-    { input: { url: "/path/to/filename.ext", opts: undefined }, out: "filename.ext" },
-    { input: { url: "/path/to/.hidden-file", opts: undefined }, out: ".hidden-file" },
-    { input: { url: "/path/to/filename.ext", opts: { strict: false } }, out: "filename.ext" },
-    { input: { url: "/path/to/.hidden-file", opts: { strict: false } }, out: ".hidden-file" },
-    { input: { url: "/path/to/dir/", opts: { strict: false } }, out: undefined },
-    { input: { url: ".", opts: { strict: false } }, out: undefined },
-    { input: { url: "/", opts: { strict: false } }, out: undefined },
-    { input: { url: "", opts: { strict: false } }, out: undefined },
+  const tests = [
+    { input: ["/path/to/filename.ext", false], out: "filename.ext" },
+    { input: ["/path/to/.hidden-file", false], out: ".hidden-file" },
+    { input: ["/path/to/dir/", false], out: undefined },
+    { input: [".", false], out: undefined },
+    { input: ["/", false], out: undefined },
+    { input: ["", false], out: undefined },
     {
-      input: { url: "http://example.com/path/to/filename.ext", opts: { strict: false } },
+      input: ["http://example.com/path/to/filename.ext", false],
       out: "filename.ext",
     },
     {
-      input: { url: "http://example.com/path/to/filename.ext?query=true", opts: { strict: false } },
+      input: ["http://example.com/path/to/filename.ext?query=true", false],
       out: "filename.ext",
     },
     {
-      input: { url: "http://example.com/path/to/filename.ext#hash", opts: { strict: false } },
+      input: ["http://example.com/path/to/filename.ext#hash", false],
       out: "filename.ext",
     },
     {
-      input: { url: "http://example.com/path/to/filename.ext?query=true#hash", opts: { strict: false } },
+      input: ["http://example.com/path/to/filename.ext?query=true#hash", false],
       out: "filename.ext",
     },
     {
-      input: {
-        url:
-          "http://example.com/path/to/filename.ext/?query=true#hash",
-        opts: {
-          strict:
-            false,
-        }
-      },
+      input: [
+        "http://example.com/path/to/filename.ext/?query=true#hash",
+        false,
+      ],
       out: undefined,
     },
-    { input: { url: "http://example.com/path/to/dir/", opts: { strict: false } }, out: undefined },
+    { input: ["http://example.com/path/to/dir/", false], out: undefined },
     {
-      input: { url: "http://example.com/path/to/dir/?query=true#hash", opts: { strict: false } },
+      input: ["http://example.com/path/to/dir/?query=true#hash", false],
       out: undefined,
     },
-    { input: { url: "http://example.com/path/to/dir/#hash", opts: { strict: false } }, out: undefined },
-    { input: { url: "http://example.com", opts: { strict: false } }, out: undefined },
+    { input: ["http://example.com/path/to/dir/#hash", false], out: undefined },
+    { input: ["http://example.com", false], out: undefined },
     {
-      input: { url: "ftp://example.com/path/to/filename.ext", opts: { strict: false } },
+      input: ["ftp://example.com/path/to/filename.ext", false],
       out: "filename.ext",
     },
-    { input: { url: "file:///path/to/filename.ext", opts: { strict: false } }, out: "filename.ext" },
-    { input: { url: "/path/to/filename.ext", opts: { strict: true } }, out: "filename.ext" },
-    { input: { url: "/path/to/.hidden-file", opts: { strict: true } }, out: undefined },
-    { input: { url: "/path/to/dir/", opts: { strict: true } }, out: undefined },
-    { input: { url: ".", opts: { strict: true } }, out: undefined },
-    { input: { url: "/", opts: { strict: true } }, out: undefined },
-    { input: { url: "", opts: { strict: true } }, out: undefined },
+    { input: ["file:///path/to/filename.ext", false], out: "filename.ext" },
+    { input: ["/path/to/filename.ext", true], out: "filename.ext" },
+    { input: ["/path/to/.hidden-file", true], out: undefined },
+    { input: ["/path/to/dir/", true], out: undefined },
+    { input: [".", true], out: undefined },
+    { input: ["/", true], out: undefined },
+    { input: ["", true], out: undefined },
     {
-      input: {
-        url: "http://example.com/path/to/filename.ext", opts: { strict: true }
-      },
-      out: "filename.ext",
-    },
-    {
-      input: {
-        url: "http://example.com/path/to/filename.ext?query=true", opts: { strict: true }
-      },
+      input: ["http://example.com/path/to/filename.ext", true],
       out: "filename.ext",
     },
     {
-      input: {
-        url: "http://example.com/path/to/filename.ext#hash", opts: { strict: true }
-      },
+      input: ["http://example.com/path/to/filename.ext?query=true", true],
       out: "filename.ext",
     },
     {
-      input: {
-        url: "http://example.com/path/to/filename.ext?query=true#hash", opts: { strict: true }
-      },
+      input: ["http://example.com/path/to/filename.ext#hash", true],
       out: "filename.ext",
     },
     {
-      input: {
-        url: "http://example.com/path/to/filename.ext/?query=true#hash", opts: { strict: true }
-      },
+      input: ["http://example.com/path/to/filename.ext?query=true#hash", true],
+      out: "filename.ext",
+    },
+    {
+      input: ["http://example.com/path/to/filename.ext/?query=true#hash", true],
       out: undefined,
     },
-    { input: { url: "http://example.com/path/to/dir/", opts: { strict: true } }, out: undefined },
+    { input: ["http://example.com/path/to/dir/", true], out: undefined },
     {
-      input: {
-        url: "http://example.com/path/to/dir/?query=true#hash", opts: { strict: true }
-      },
+      input: ["http://example.com/path/to/dir/?query=true#hash", true],
       out: undefined,
     },
-    { input: { url: "http://example.com/path/to/dir/#hash", opts: { strict: true } }, out: undefined },
-    { input: { url: "http://example.com", opts: { strict: true } }, out: undefined },
+    { input: ["http://example.com/path/to/dir/#hash", true], out: undefined },
+    { input: ["http://example.com", true], out: undefined },
     {
-      input: {
-        url: "ftp://example.com/path/to/filename.ext", opts: { strict: true }
-      },
+      input: ["ftp://example.com/path/to/filename.ext", true],
       out: "filename.ext",
     },
-    { input: { url: "file:///path/to/filename.ext", opts: { strict: true } }, out: "filename.ext" },
-    { input: { url: "/path/to/filename.ext/", opts: { strict: true } }, out: undefined },
-    { input: { url: "/path/to/dir/../filename.ext", opts: { strict: true } }, out: "filename.ext" },
-    { input: { url: "/path/to/dir/../filename.ext/", opts: { strict: true } }, out: undefined },
-  ];
+    { input: ["file:///path/to/filename.ext", true], out: "filename.ext" },
+    { input: ["/path/to/filename.ext/", true], out: undefined },
+    { input: ["/path/to/dir/../filename.ext", true], out: "filename.ext" },
+    { input: ["/path/to/dir/../filename.ext/", true], out: undefined },
+  ] as const;
+
+  test("works", () => {
+    expect(parseFilename("/path/to/filename.ext")).toEqual("filename.ext");
+  });
 
   for (const t of tests) {
-    test(t.input.url.toString(), () => {
+    test(t.input.toString(), () => {
       expect(
-        parseFilename(t.input.url.toString(), t.input.opts),
+        parseFilename(t.input[0].toString(), { strict: t.input[1] }),
       ).toStrictEqual(t.out);
     });
   }


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

Resolves #283 
This PR, for `parseFilename`
- Fixes incorrect access of options 
- Exposes a `ParseFilenameOptions` interface
- Refactors tests for readability improvements and adding cases without options
