### PR TITLE
fix(query): use `Object.create(null)`

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -18,6 +18,12 @@ export type QueryObject = Record<string, QueryValue | QueryValue[]>;
 
 export type ParsedQuery = Record<string, string | string[]>;
 
+// const EmptyObject = /* @__PURE__ */ (() => {
+//   const C = function () {};
+//   C.prototype = Object.create(null);
+//   return C;
+// })() as unknown as { new (): any };
+
 /**
  * Parses and decodes a query string into an object.
  *
@@ -31,6 +37,8 @@ export type ParsedQuery = Record<string, string | string[]>;
 export function parseQuery<T extends ParsedQuery = ParsedQuery>(
   parametersString = "",
 ): T {
+  // TODO: Use new EmptyObject() instead of Object.create(null) for better performance in next major version
+  // https://github.com/unjs/ufo/pull/290
   const object: ParsedQuery = Object.create(null);
   if (parametersString[0] === "?") {
     parametersString = parametersString.slice(1);

--- a/src/query.ts
+++ b/src/query.ts
@@ -18,12 +18,6 @@ export type QueryObject = Record<string, QueryValue | QueryValue[]>;
 
 export type ParsedQuery = Record<string, string | string[]>;
 
-const EmptyObject = /* @__PURE__ */ (() => {
-  const C = function () {};
-  C.prototype = Object.create(null);
-  return C;
-})() as unknown as { new (): any };
-
 /**
  * Parses and decodes a query string into an object.
  *
@@ -37,7 +31,7 @@ const EmptyObject = /* @__PURE__ */ (() => {
 export function parseQuery<T extends ParsedQuery = ParsedQuery>(
   parametersString = "",
 ): T {
-  const object: ParsedQuery = new EmptyObject();
+  const object: ParsedQuery = Object.create(null);
   if (parametersString[0] === "?") {
     parametersString = parametersString.slice(1);
   }


### PR DESCRIPTION
resolve an ecosystem regrerssion introduced from #286 

Using a custom class with null prototype adds [performance benefits](https://jsbenchmark.com/#eyJjYXNlcyI6W3siaWQiOiJQdEZfRWZzQzFVWjRaTXBTU1BWTG4iLCJjb2RlIjoiQXJyYXkuZnJvbSh7bGVuZ3RoOiAxMDAwMH0sICgpID0-IG5ldyBEQVRBLkVtcHR5T2JqZWN0KCkpIiwibmFtZSI6IkVtcHR5T2JqZWN0IiwiZGVwZW5kZW5jaWVzIjpbXX0seyJpZCI6Ink4ZHkxeS1ENV8xV3lDeUFRaEJZNyIsImNvZGUiOiJBcnJheS5mcm9tKHtsZW5ndGg6IDEwMDAwfSwgKCkgPT4gREFUQS5PYmplY3RDcmVhdGUoKSkiLCJuYW1lIjoiT2JqZWN0Q3JlYXRlIiwiZGVwZW5kZW5jaWVzIjpbXX1dLCJjb25maWciOnsibmFtZSI6IkJhc2ljIGV4YW1wbGUiLCJwYXJhbGxlbCI6dHJ1ZSwiZ2xvYmFsVGVzdENvbmZpZyI6eyJkZXBlbmRlbmNpZXMiOltdfSwiZGF0YUNvZGUiOiJjb25zdCBFbXB0eU9iamVjdCA9IC8qIEBfX1BVUkVfXyAqLyAoKCkgPT4ge1xuICBjb25zdCBDID0gZnVuY3Rpb24gKCkge307XG4gIEMucHJvdG90eXBlID0gT2JqZWN0LmNyZWF0ZShudWxsKTtcbiAgcmV0dXJuIEM7XG59KSgpO1xuXG5yZXR1cm4geyBFbXB0eU9iamVjdCwgT2JqZWN0Q3JlYXRlOiAoKSA9PiBPYmplY3QuY3JlYXRlKG51bGwpIH0ifX0) but also breaks libraries like devalue that explicitly check `Object.getPrototypeOf() === null`)

This PR uses a slower `Object.create(null)` to improve ecosystem compatibility for the time being.