### PR TITLE
docs: add more examples in jsdoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,23 @@ parseFilename("/path/to/.hidden-file", { strict: true });
 
 Takes a string, and returns an object with two properties: `hostname` and `port`.
 
+**Example:**
+
+```js
+parseHost("foo.com:8080");
+// { hostname: 'foo.com', port: '8080' }
+```
+
 ### `parsePath(input)`
 
 Splits the input string into three parts, and returns an object with those three parts.
+
+**Example:**
+
+```js
+parsePath("http://foo.com/foo?test=123#token");
+// { pathname: 'http://foo.com/foo', search: '?test=123', hash: '#token' }
+```
 
 ### `parseURL(input, defaultProto?)`
 
@@ -156,15 +170,42 @@ Encodes a pair of key and value into a url query string value.
 
 If the value is an array, it will be encoded as multiple key-value pairs with the same key.
 
+**Example:**
+
+```js
+encodeQueryItem('message', 'Hello World')
+// 'message=Hello+World'
+
+encodeQueryItem('tags', ['javascript', 'web', 'dev'])
+// 'tags=javascript&tags=web&tags=dev'
+```
+
 ### `parseQuery(parametersString)`
 
 Parses and decodes a query string into an object.
 
 The input can be a query string with or without the leading `?`.
 
+**Example:**
+
+```js
+parseQuery("?foo=bar&baz=qux");
+// { foo: "bar", baz: "qux" }
+```
+
 ### `stringifyQuery(query)`
 
 Stringfies and encodes a query object into a query string.
+
+**Example:**
+
+```js
+stringifyQuery({ foo: 'bar', baz: 'qux' })
+// 'foo=bar&baz=qux'
+
+stringifyQuery({ foo: 'bar', baz: undefined })
+// 'foo=bar'
+```
 
 ## Utils
 
@@ -213,6 +254,18 @@ Checks if the input has a leading slash (e.g. `/foo`).
 ### `hasTrailingSlash(input, respectQueryAndFragment?)`
 
 Checks if the input has a trailing slash.
+
+**Example:**
+
+```js
+hasTrailingSlash("/foo/"); // true
+
+hasTrailingSlash("/foo"); // false
+
+hasTrailingSlash("/foo?query=true", true); // false
+
+hasTrailingSlash("/foo/?query=true", true); // true
+```
 
 ### `isEmptyURL(url)`
 
@@ -267,6 +320,21 @@ isSamePath("/foo", "/foo/"); // true
 
 Checks if the input protocol is any of the dangerous `blob:`, `data:`, `javascript`: or `vbscript:` protocols.
 
+**Example:**
+
+```js
+isScriptProtocol("javascript:alert(1)"); // true
+
+isScriptProtocol("data:text/html,hello"); // true
+
+isScriptProtocol("blob:hello"); // true
+
+isScriptProtocol("vbscript:alert(1)"); // true
+
+isScriptProtocol("https://example.com"); // false
+
+```
+
 ### `joinRelativeURL()`
 
 Joins multiple URL segments into a single URL and also handles relative paths with `./` and `../`.
@@ -320,6 +388,14 @@ Ensures the URL or pathname starts with base.
 
 If input already starts with base, it will not be added again.
 
+**Example:**
+
+```js
+withBase("/foo/bar", "/foo"); // "/foo/bar"
+
+withBase("/foo/bar", "/baz"); // "/baz/foo/bar"
+```
+
 ### `withFragment(input, hash)`
 
 Adds or replaces the fragment section of the URL.
@@ -356,11 +432,23 @@ withHttps("http://example.com"); // https://example.com
 
 Ensures the URL or pathname has a leading slash.
 
+**Example:**
+
+```js
+withLeadingSlash("foo"); // "/foo"
+```
+
 ### `withoutBase(input, base)`
 
 Removes the base from the URL or pathname.
 
 If input does not start with base, it will not be removed.
+
+**Example:**
+
+```js
+withoutBase("/foo/bar", "/foo"); // "/bar"
+```
 
 ### `withoutFragment(input)`
 
@@ -387,6 +475,12 @@ withoutHost("http://example.com/foo?q=123#bar")
 ### `withoutLeadingSlash(input)`
 
 Removes leading slash from the URL or pathname.
+
+**Example:**
+
+```js
+withoutLeadingSlash("/foo"); // "foo"
+```
 
 ### `withoutProtocol(input)`
 

--- a/README.md
+++ b/README.md
@@ -355,7 +355,6 @@ isScriptProtocol("blob:hello"); // true
 isScriptProtocol("vbscript:alert(1)"); // true
 
 isScriptProtocol("https://example.com"); // false
-
 ```
 
 ### `joinRelativeURL()`

--- a/README.md
+++ b/README.md
@@ -191,6 +191,9 @@ The input can be a query string with or without the leading `?`.
 ```js
 parseQuery("?foo=bar&baz=qux");
 // { foo: "bar", baz: "qux" }
+
+parseQuery("tags=javascript&tags=web&tags=dev");
+// { tags: ["javascript", "web", "dev"] }
 ```
 
 ### `stringifyQuery(query)`
@@ -250,6 +253,26 @@ getQuery("http://foo.com/foo?test=123&unicode=%E5%A5%BD");
 Checks if the input has a leading slash (e.g. `/foo`).
 
 ### `hasProtocol(inputString, opts)`
+
+Checks if the input has a protocol.
+
+You can use `{ acceptRelative: true }` to accept relative URLs as valid protocol.
+
+**Example:**
+
+```js
+hasProtocol('https://example.com'); // true
+
+hasProtocol("//example.com"); // false
+
+hasProtocol('//example.com', { acceptRelative: true });  // true
+
+hasProtocol("ftp://example.com"); // true
+
+hasProtocol('data:text/plain'); // true
+
+hasProtocol('data:text/plain', { strict: true }); // false
+```
 
 ### `hasTrailingSlash(input, respectQueryAndFragment?)`
 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -95,6 +95,13 @@ export function parseURL(input = "", defaultProto?: string): ParsedURL {
 /**
  * Splits the input string into three parts, and returns an object with those three parts.
  *
+ * @example
+ *
+ * ```js
+ * parsePath("http://foo.com/foo?test=123#token");
+ * // { pathname: 'http://foo.com/foo', search: '?test=123', hash: '#token' }
+ * ```
+ *
  * @group parsing_utils
  *
  * @param [input] - The URL to parse.
@@ -131,6 +138,13 @@ export function parseAuth(input = ""): ParsedAuth {
 
 /**
  * Takes a string, and returns an object with two properties: `hostname` and `port`.
+ *
+ * @example
+ *
+ * ```js
+ * parseHost("foo.com:8080");
+ * // { hostname: 'foo.com', port: '8080' }
+ * ```
  *
  * @group parsing_utils
  *

--- a/src/query.ts
+++ b/src/query.ts
@@ -34,6 +34,9 @@ export type ParsedQuery = Record<string, string | string[]>;
  * ```js
  * parseQuery("?foo=bar&baz=qux");
  * // { foo: "bar", baz: "qux" }
+ *
+ * parseQuery("tags=javascript&tags=web&tags=dev");
+ * // { tags: ["javascript", "web", "dev"] }
  * ```
  *
  * @note

--- a/src/query.ts
+++ b/src/query.ts
@@ -80,7 +80,7 @@ export function parseQuery<T extends ParsedQuery = ParsedQuery>(
  *
  * ```js
  * encodeQueryItem('message', 'Hello World')
- * // 'message=Hello%20World'
+ * // 'message=Hello+World'
  *
  * encodeQueryItem('tags', ['javascript', 'web', 'dev'])
  * // 'tags=javascript&tags=web&tags=dev'

--- a/src/query.ts
+++ b/src/query.ts
@@ -29,6 +29,13 @@ export type ParsedQuery = Record<string, string | string[]>;
  *
  * The input can be a query string with or without the leading `?`.
  *
+ * @example
+ *
+ * ```js
+ * parseQuery("?foo=bar&baz=qux");
+ * // { foo: "bar", baz: "qux" }
+ * ```
+ *
  * @note
  * The `__proto__` and `constructor` keys are ignored to prevent prototype pollution.
  *
@@ -69,6 +76,16 @@ export function parseQuery<T extends ParsedQuery = ParsedQuery>(
  *
  * If the value is an array, it will be encoded as multiple key-value pairs with the same key.
  *
+ * @example
+ *
+ * ```js
+ * encodeQueryItem('message', 'Hello World')
+ * // 'message=Hello%20World'
+ *
+ * encodeQueryItem('tags', ['javascript', 'web', 'dev'])
+ * // 'tags=javascript&tags=web&tags=dev'
+ * ```
+ *
  * @group Query_utils
  */
 export function encodeQueryItem(
@@ -96,6 +113,16 @@ export function encodeQueryItem(
 
 /**
  * Stringfies and encodes a query object into a query string.
+ *
+ * @example
+ *
+ * ```js
+ * stringifyQuery({ foo: 'bar', baz: 'qux' })
+ * // 'foo=bar&baz=qux'
+ *
+ * stringifyQuery({ foo: 'bar', baz: undefined })
+ * // 'foo=bar'
+ * ```
  *
  * @group Query_utils
  */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -34,7 +34,6 @@ export interface HasProtocolOptions {
   strict?: boolean;
 }
 
-
 export function hasProtocol(
   inputString: string,
   opts?: HasProtocolOptions,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -100,7 +100,6 @@ export function hasProtocol(
  * isScriptProtocol("vbscript:alert(1)"); // true
  *
  * isScriptProtocol("https://example.com"); // false
- *
  * ```
  *
  * @group utils

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -39,6 +39,22 @@ export interface HasProtocolOptions {
  *
  * You can use `{ acceptRelative: true }` to accept relative URLs as valid protocol.
  *
+ * @example
+ *
+ * ```js
+ * hasProtocol('https://example.com'); // true
+ *
+ * hasProtocol("//example.com"); // false
+ *
+ * hasProtocol('//example.com', { acceptRelative: true });  // true
+ *
+ * hasProtocol("ftp://example.com"); // true
+ *
+ * hasProtocol('data:text/plain'); // true
+ *
+ * hasProtocol('data:text/plain', { strict: true }); // false
+ * ```
+ *
  * @group utils
  */
 export function hasProtocol(
@@ -69,6 +85,21 @@ export function hasProtocol(
 /**
  * Checks if the input protocol is any of the dangerous `blob:`, `data:`, `javascript`: or `vbscript:` protocols.
  *
+ * @example
+ *
+ * ```js
+ * isScriptProtocol("javascript:alert(1)"); // true
+ *
+ * isScriptProtocol("data:text/html,hello"); // true
+ *
+ * isScriptProtocol("blob:hello"); // true
+ *
+ * isScriptProtocol("vbscript:alert(1)"); // true
+ *
+ * isScriptProtocol("https://example.com"); // false
+ *
+ * ```
+ *
  * @group utils
  */
 export function isScriptProtocol(protocol?: string) {
@@ -77,6 +108,18 @@ export function isScriptProtocol(protocol?: string) {
 
 /**
  * Checks if the input has a trailing slash.
+ *
+ * @example
+ *
+ * ```js
+ * hasTrailingSlash("/foo/"); // true
+ *
+ * hasTrailingSlash("/foo"); // false
+ *
+ * hasTrailingSlash("/foo?query=true", true); // false
+ *
+ * hasTrailingSlash("/foo/?query=true", true); // true
+ * ```
  *
  * @group utils
  */
@@ -180,6 +223,12 @@ export function hasLeadingSlash(input = ""): boolean {
 /**
  * Removes leading slash from the URL or pathname.
  *
+ * @example
+ *
+ * ```js
+ * withoutLeadingSlash("/foo"); // "foo"
+ * ```
+ *
  * @group utils
  */
 export function withoutLeadingSlash(input = ""): string {
@@ -188,6 +237,12 @@ export function withoutLeadingSlash(input = ""): string {
 
 /**
  * Ensures the URL or pathname has a leading slash.
+ *
+ * @example
+ *
+ * ```js
+ * withLeadingSlash("foo"); // "/foo"
+ * ```
  *
  * @group utils
  */
@@ -221,6 +276,14 @@ export function cleanDoubleSlashes(input = ""): string {
  *
  * If input already starts with base, it will not be added again.
  *
+ * @example
+ *
+ * ```js
+ * withBase("/foo/bar", "/foo"); // "/foo/bar"
+ *
+ * withBase("/foo/bar", "/baz"); // "/baz/foo/bar"
+ * ```
+ *
  * @group utils
  */
 export function withBase(input: string, base: string) {
@@ -238,6 +301,12 @@ export function withBase(input: string, base: string) {
  * Removes the base from the URL or pathname.
  *
  * If input does not start with base, it will not be removed.
+ *
+ * @example
+ *
+ * ```js
+ * withoutBase("/foo/bar", "/foo"); // "/bar"
+ * ```
  *
  * @group utils
  */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -34,6 +34,18 @@ export interface HasProtocolOptions {
   strict?: boolean;
 }
 
+
+export function hasProtocol(
+  inputString: string,
+  opts?: HasProtocolOptions,
+): boolean;
+
+/** @deprecated Same as { hasProtocol(inputString, { acceptRelative: true }) */
+export function hasProtocol(
+  inputString: string,
+  acceptRelative: boolean,
+): boolean;
+
 /**
  * Checks if the input has a protocol.
  *
@@ -57,15 +69,6 @@ export interface HasProtocolOptions {
  *
  * @group utils
  */
-export function hasProtocol(
-  inputString: string,
-  opts?: HasProtocolOptions,
-): boolean;
-/** @deprecated Same as { hasProtocol(inputString, { acceptRelative: true }) */
-export function hasProtocol(
-  inputString: string,
-  acceptRelative: boolean,
-): boolean;
 export function hasProtocol(
   inputString: string,
   opts: boolean | HasProtocolOptions = {},


### PR DESCRIPTION
In this PR, I’ve added JSDoc comments to most of the utility functions, in the hope that these examples can help users better understand the purpose and usage of each function.

Perhaps we could also consider including some of them in the README?