### PR TITLE
fix(encoding): encode '?' as %3F in query values

### DIFF
--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -64,6 +64,7 @@ export function encodeQueryValue(input: QueryValue): string {
       .replace(ENC_SPACE_RE, "+")
       .replace(HASH_RE, "%23")
       .replace(AMPERSAND_RE, "%26")
+      .replace(IM_RE, "%3F")
       .replace(ENC_BACKTICK_RE, "`")
       .replace(ENC_CARET_RE, "^")
       .replace(SLASH_RE, "%2F")

--- a/test/encoding.test.ts
+++ b/test/encoding.test.ts
@@ -95,8 +95,10 @@ describe("encodeQueryValue", () => {
     },
     {
       input: String.raw`!@#$%^&*()_+{}[]|\:;<>,./?`,
-      out: "!@%23$%25^%26*()_%2B%7B%7D%5B%5D|%5C:;%3C%3E,.%2F?",
+      out: "!@%23$%25^%26*()_%2B%7B%7D%5B%5D|%5C:;%3C%3E,.%2F%3F",
     },
+    { input: "https://example.com?foo=bar", out: "https:%2F%2Fexample.com%3Ffoo=bar" },
+    { input: "path?query=value", out: "path%3Fquery=value" },
   ];
 
   for (const t of tests) {

--- a/test/encoding.test.ts
+++ b/test/encoding.test.ts
@@ -97,7 +97,10 @@ describe("encodeQueryValue", () => {
       input: String.raw`!@#$%^&*()_+{}[]|\:;<>,./?`,
       out: "!@%23$%25^%26*()_%2B%7B%7D%5B%5D|%5C:;%3C%3E,.%2F%3F",
     },
-    { input: "https://example.com?foo=bar", out: "https:%2F%2Fexample.com%3Ffoo=bar" },
+    {
+      input: "https://example.com?foo=bar",
+      out: "https:%2F%2Fexample.com%3Ffoo=bar",
+    },
     { input: "path?query=value", out: "path%3Fquery=value" },
   ];
 

--- a/test/normalize.test.ts
+++ b/test/normalize.test.ts
@@ -31,7 +31,7 @@ describe("normalizeURL", () => {
     "http://[2001:db8:85a3:8d3:1319:8a2e:370:7348]/":
       "http://[2001:db8:85a3:8d3:1319:8a2e:370:7348]/",
     "http://localhost/?redirect=http:%2F%2Fgoogle.com?q=test":
-      "http://localhost/?redirect=http:%2F%2Fgoogle.com?q=test",
+      "http://localhost/?redirect=http:%2F%2Fgoogle.com%3Fq=test",
     "http://localhost/?email=some+v1@email.com":
       "http://localhost/?email=some+v1@email.com",
     "http://localhost/?email=some%2Bv1%40email.com":

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -63,6 +63,16 @@ describe("withQuery", () => {
       query: { a: "X", "b[]": [], c: "Y" },
       out: "/?a=X&c=Y",
     },
+    {
+      input: "/",
+      query: { url: "https://google.com?query=123" },
+      out: "/?url=https:%2F%2Fgoogle.com%3Fquery=123",
+    },
+    {
+      input: "/login",
+      query: { to: "/article?id=1" },
+      out: "/login?to=%2Farticle%3Fid=1",
+    },
   ];
 
   for (const t of tests) {


### PR DESCRIPTION
## Problem

Fixes #301.

`encodeQueryValue` does not encode the `?` character, so embedding a URL-with-query-string as a query parameter value produces an ambiguous result:

```js
withQuery('/', { url: 'https://google.com?query=123' })
// Actual:   /?url=https:%2F%2Fgoogle.com?query=123   ← bare ? breaks parsers
// Expected: /?url=https:%2F%2Fgoogle.com%3Fquery=123
```

This breaks HTTP infrastructure that validates query strings strictly — AWS API Gateway returns `400 InvalidQueryStringException` when it encounters an unescaped `?` in a query value (reported in issue comments).

## Root Cause

`encodeQueryValue` already has a `IM_RE = /\?/g` constant defined at the top of `encoding.ts` (used correctly in `encodePath`), but it was never applied in `encodeQueryValue`.

## Fix

Add `.replace(IM_RE, "%3F")` to `encodeQueryValue` — one line, same pattern as the existing `#`, `&`, `+`, `/` replacements.

## Tests

- Updated existing `encodeQueryValue` test: the trailing `?` in the big character-class case now correctly encodes to `%3F`.
- Added two new `encodeQueryValue` cases: URL-with-query-string as value, and `path?query=value`.
- Added two new `withQuery` cases covering the exact scenarios from issue #301 (Google URL redirect, `/article?id=1` login redirect).
- Updated one `normalizeURL` test whose expected output was the buggy pre-fix value (`google.com?q=test` → `google.com%3Fq=test`).

## Verification

- `vitest run --typecheck` — 491/491 ✅, 14 test files, 0 type errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Question marks in query parameter values are now correctly percent-encoded as %3F.

* **Tests**
  * Updated and added tests to cover percent-encoding of URLs and special characters within query values, including nested/redirected query scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->