### PR TITLE
fix(encoding): keep caret and backtick encoded in query values (#302, #304)

### DIFF
--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -64,8 +64,7 @@ export function encodeQueryValue(input: QueryValue): string {
       .replace(ENC_SPACE_RE, "+")
       .replace(HASH_RE, "%23")
       .replace(AMPERSAND_RE, "%26")
-      .replace(ENC_BACKTICK_RE, "`")
-      .replace(ENC_CARET_RE, "^")
+      // ^ (`%5E`) and backtick (`%60`) must remain encoded per RFC 1738
       .replace(SLASH_RE, "%2F")
   );
 }


### PR DESCRIPTION
Fixes #302
Fixes #304

## Problem

`encodeQueryValue` was un-encoding `%5E` (`^`) and `%60` (backtick) back to their raw characters after `encodeURI()` encoded them.

## Fix

Remove the two `.replace()` calls that un-encode caret and backtick in `encodeQueryValue`. Per RFC 1738 Section 2.2, both are unsafe characters that must remain encoded in query values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed query value encoding to keep backtick and caret characters properly percent-encoded in query strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->