### PR TITLE
fix: keep backtick and caret encoded in encodeQueryValue

### DIFF
--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -64,8 +64,8 @@ export function encodeQueryValue(input: QueryValue): string {
       .replace(ENC_SPACE_RE, "+")
       .replace(HASH_RE, "%23")
       .replace(AMPERSAND_RE, "%26")
-      .replace(ENC_BACKTICK_RE, "`")
-      .replace(ENC_CARET_RE, "^")
+      // backtick (%60) stays encoded per RFC 1738 (#302)
+      // caret (%5E) stays encoded per RFC 1738 (#304)
       .replace(SLASH_RE, "%2F")
   );
 }


### PR DESCRIPTION
## Problem

encodeQueryValue does not properly encode backtick and caret characters.

encodeURI encodes these correctly, but encodeQueryValue then decodes them back:
- encodeURI converts backtick to %60, then .replace(ENC_BACKTICK_RE, "`") undoes it
- encodeURI converts caret to %5E, then .replace(ENC_CARET_RE, "^") undoes it

Per RFC 1738 Section 2.2, both backtick and caret are "unsafe" characters that should be encoded.

Fixes #302, #304

## Fix

Remove the two .replace() lines in encodeQueryValue that decode backtick and caret back to their raw characters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed query parameter encoding to properly handle special characters in URLs, ensuring backticks and carets are correctly percent-encoded for improved URL consistency and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->