### PR TITLE
fix: keep caret and backtick encoded in encodeQueryValue (#302, #304)

### DIFF
--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -64,8 +64,6 @@ export function encodeQueryValue(input: QueryValue): string {
       .replace(ENC_SPACE_RE, "+")
       .replace(HASH_RE, "%23")
       .replace(AMPERSAND_RE, "%26")
-      .replace(ENC_BACKTICK_RE, "`")
-      .replace(ENC_CARET_RE, "^")
       .replace(SLASH_RE, "%2F")
   );
 }


### PR DESCRIPTION
### Linked issues

Closes #302, Closes #304

### Description

`encodeQueryValue` decodes `%5E` back to `^` and `%60` back to backtick after `encodeURI()` encodes them. This contradicts RFC 1738 Section 2.2 which lists both as "Unsafe" characters that should be encoded.

```
encodeQueryValue('^')   // returns '^'  (should be '%5E')
encodeQueryValue('`')   // returns '`'  (should be '%60')
```

The lines `.replace(ENC_BACKTICK_RE, ...)` and `.replace(ENC_CARET_RE, ...)` explicitly undo the encoding that `encodeURI()` performs.

### Fix

Remove the two `.replace()` calls that decode caret and backtick:

```diff
  .replace(HASH_RE, "%23")
  .replace(AMPERSAND_RE, "%26")
- .replace(ENC_BACKTICK_RE, "`")
- .replace(ENC_CARET_RE, "^")
  .replace(SLASH_RE, "%2F")
```

Note: `encodeHash` intentionally keeps these decoded (for fragment identifiers). Only `encodeQueryValue` is affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced query parameter encoding to improve reliability and consistency. Search queries and application URLs with special characters are now processed more accurately, eliminating unexpected character conversions that could impact search functionality or URL behavior. This ensures more reliable search results and consistent application performance when navigating with complex queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->