### PR TITLE
fix: preserve array markers in parseQuery

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -59,12 +59,13 @@ export function parseQuery<T extends ParsedQuery = ParsedQuery>(
       continue;
     }
     const key = decodeQueryKey(s[1]);
+    const isArrayKey = key.endsWith("[]");
     if (key === "__proto__" || key === "constructor") {
       continue;
     }
     const value = decodeQueryValue(s[2] || "");
     if (object[key] === undefined) {
-      object[key] = value;
+      object[key] = isArrayKey ? [value] : value;
     } else if (Array.isArray(object[key])) {
       (object[key] as string[]).push(value);
     } else {

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { filterQuery, getQuery, withQuery } from "../src";
+import { filterQuery, getQuery, parseQuery, withQuery } from "../src";
 
 describe("withQuery", () => {
   const tests = [
@@ -108,4 +108,26 @@ describe("getQuery", () => {
       expect(getQuery(t)).toMatchObject(tests[t]);
     });
   }
+});
+
+describe("parseQuery", () => {
+  test("treats a single []-suffixed key as an array value", () => {
+    expect(parseQuery("filter[size][]=large")).toMatchObject({
+      "filter[size][]": ["large"],
+    });
+  });
+
+  test("preserves repeated []-suffixed keys as arrays", () => {
+    expect(
+      parseQuery("filter[size][]=large&filter[size][]=medium"),
+    ).toMatchObject({
+      "filter[size][]": ["large", "medium"],
+    });
+  });
+
+  test("keeps non-array keys as scalar values", () => {
+    expect(parseQuery("filter[size]=large")).toMatchObject({
+      "filter[size]": "large",
+    });
+  });
 });


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Query parameters with the `[]` suffix are now correctly parsed as arrays, enabling proper handling of multiple values for the same parameter key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->