### PR TITLE
fix(encodeQueryValue): encode caret and backtick in query values

### DIFF
--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -64,8 +64,6 @@ export function encodeQueryValue(input: QueryValue): string {
       .replace(ENC_SPACE_RE, "+")
       .replace(HASH_RE, "%23")
       .replace(AMPERSAND_RE, "%26")
-      .replace(ENC_BACKTICK_RE, "`")
-      .replace(ENC_CARET_RE, "^")
       .replace(SLASH_RE, "%2F")
   );
 }

--- a/test/encoding.test.ts
+++ b/test/encoding.test.ts
@@ -89,13 +89,15 @@ describe("encodeQueryValue", () => {
     { input: true, out: "true" },
     { input: 42, out: "42" },
     { input: "a=1&b=2", out: "a=1%26b=2" },
+    { input: "^", out: "%5E" }, // #304
+    { input: "a`b", out: "a%60b" }, // #302
     {
       input: ["apple", "banana", "cherry"],
       out: "apple,banana,cherry",
     },
     {
       input: String.raw`!@#$%^&*()_+{}[]|\:;<>,./?`,
-      out: "!@%23$%25^%26*()_%2B%7B%7D%5B%5D|%5C:;%3C%3E,.%2F?",
+      out: "!@%23$%25%5E%26*()_%2B%7B%7D%5B%5D|%5C:;%3C%3E,.%2F?",
     },
   ];
 


### PR DESCRIPTION
### Bug Description

`encodeQueryValue('^')` returns `^` instead of `%5E`, and `encodeQueryValue("a`b")` returns `` a`b `` instead of `a%60b`. These characters are intentionally decoded back after `encodeURI` encodes them, which:

1. **Breaks round-trip encoding**: encoded values decode back to the original, defeating the purpose of encoding
2. **Violates RFC 3986**: both `^` and backtick are unsafe characters that must be percent-encoded in query values

### Root Cause

In `src/encoding.ts`, `encodeQueryValue()` had explicit `.replace(ENC_BACKTICK_RE, "\`")` and `.replace(ENC_CARET_RE, "^")` calls that decoded these characters back after `encodeURI` correctly encoded them.

### Changes

- Remove `.replace(ENC_BACKTICK_RE, "\`")` that decoded `%60` back to backtick
- Remove `.replace(ENC_CARET_RE, "^")` that decoded `%5E` back to `^`
- Add specific test cases for both characters
- Update existing special chars test to expect `%5E` for `^`

### Related Issues

- Fixes #304
- Fixes #302

### Test Results

All 487 tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed query parameter encoding behavior. Backtick and caret characters in query parameters now remain properly percent-encoded rather than being incorrectly decoded to their literal symbols, ensuring URLs are correctly formatted and function as intended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->