### PR TITLE
fix: encode ^ and backtick characters in encodeQueryValue

### DIFF
--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -64,8 +64,6 @@ export function encodeQueryValue(input: QueryValue): string {
       .replace(ENC_SPACE_RE, "+")
       .replace(HASH_RE, "%23")
       .replace(AMPERSAND_RE, "%26")
-      .replace(ENC_BACKTICK_RE, "`")
-      .replace(ENC_CARET_RE, "^")
       .replace(SLASH_RE, "%2F")
   );
 }

--- a/test/encoding.test.ts
+++ b/test/encoding.test.ts
@@ -89,13 +89,17 @@ describe("encodeQueryValue", () => {
     { input: true, out: "true" },
     { input: 42, out: "42" },
     { input: "a=1&b=2", out: "a=1%26b=2" },
+    // ^  should be percent-encoded in query values (issue #304)
+    { input: "^", out: "%5E" },
+    // backtick should be percent-encoded in query values (issue #302)
+    { input: "`", out: "%60" },
     {
       input: ["apple", "banana", "cherry"],
       out: "apple,banana,cherry",
     },
     {
       input: String.raw`!@#$%^&*()_+{}[]|\:;<>,./?`,
-      out: "!@%23$%25^%26*()_%2B%7B%7D%5B%5D|%5C:;%3C%3E,.%2F?",
+      out: "!@%23$%25%5E%26*()_%2B%7B%7D%5B%5D|%5C:;%3C%3E,.%2F?",
     },
   ];
 


### PR DESCRIPTION
## Summary

encodeQueryValue was silently undoing the percent-encoding of two unsafe characters after calling encodeURI, so they came through raw in query strings:

| Character | Before | After |
|-----------|--------|-------|
| ^ | ^ (unencoded) | %5E ✅ |
| `  ` | `  ` (unencoded) | %60 ✅ |

## Root cause

Two .replace() calls were reverting valid percent-encoding produced by encodeURI:

\\\diff
- .replace(ENC_BACKTICK_RE, '\')   // was decoding %60 → \
- .replace(ENC_CARET_RE, '^')       // was decoding %5E → ^
\\\

Per [RFC 1738 §2.2](https://datatracker.ietf.org/doc/html/rfc1738#section-2.2) both characters are **unsafe** and must be percent-encoded in URLs.

## Changes

- **\src/encoding.ts\** — removed the two decoding replacements from \encodeQueryValue\
- **\	est/encoding.test.ts\** — added explicit test cases for \^\ and \\\; updated the existing combined-chars test to expect the correct \%5E\ output

## Tests

All 487 existing tests continue to pass plus 2 new cases.

Closes #302
Closes #304

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified query value encoding to keep backticks and carets in their percent-encoded form (`%60` and `%5E` respectively) instead of converting them back to literal characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->