### PR TITLE
fix(encoding): keep backtick encoded in query values

### DIFF
--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -11,7 +11,7 @@ const IM_RE = /\?/g; // %3F
 const PLUS_RE = /\+/g; // %2B
 
 const ENC_CARET_RE = /%5e/gi; // ^
-const ENC_BACKTICK_RE = /%60/gi; // `
+// Backtick (%60) is intentionally kept encoded per RFC1738 Section 2.2
 const ENC_CURLY_OPEN_RE = /%7b/gi; // {
 const ENC_PIPE_RE = /%7c/gi; // |
 const ENC_CURLY_CLOSE_RE = /%7d/gi; // }
@@ -64,7 +64,6 @@ export function encodeQueryValue(input: QueryValue): string {
       .replace(ENC_SPACE_RE, "+")
       .replace(HASH_RE, "%23")
       .replace(AMPERSAND_RE, "%26")
-      .replace(ENC_BACKTICK_RE, "`")
       .replace(ENC_CARET_RE, "^")
       .replace(SLASH_RE, "%2F")
   );

--- a/test/encoding.test.ts
+++ b/test/encoding.test.ts
@@ -97,6 +97,7 @@ describe("encodeQueryValue", () => {
       input: String.raw`!@#$%^&*()_+{}[]|\:;<>,./?`,
       out: "!@%23$%25^%26*()_%2B%7B%7D%5B%5D|%5C:;%3C%3E,.%2F?",
     },
+    { input: "a`b", out: "a%60b" },
   ];
 
   for (const t of tests) {


### PR DESCRIPTION
## Summary

Fixes #302

Backtick (`` ` ``) was incorrectly decoded from `%60` back to a literal backtick in `encodeQueryValue`. Per [RFC1738 Section 2.2](https://datatracker.ietf.org/doc/html/rfc1738#section-2.2), backtick is an unsafe character and must remain percent-encoded.

## Root Cause

```ts
// src/encoding.ts
.replace(ENC_BACKTICK_RE, "`")  // ← decodes %60 back to `
```

This line was *un*-encoding the backtick after `encode()` had correctly encoded it.

## Fix

Removed the `.replace(ENC_BACKTICK_RE, "`")` call. Added test case.

```js
encodeQueryValue("a`b") // before: "a`b" ❌ | after: "a%60b" ✅
```

All 486 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed query value encoding to properly retain percent-encoded backticks in accordance with RFC standards.

* **Tests**
  * Added test case for backtick encoding in query values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->