### PR TITLE
fix(encoding): encode backticks in encodeQueryValue per RFC 1738

### DIFF
--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -64,7 +64,6 @@ export function encodeQueryValue(input: QueryValue): string {
       .replace(ENC_SPACE_RE, "+")
       .replace(HASH_RE, "%23")
       .replace(AMPERSAND_RE, "%26")
-      .replace(ENC_BACKTICK_RE, "`")
       .replace(ENC_CARET_RE, "^")
       .replace(SLASH_RE, "%2F")
   );

--- a/test/encoding.test.ts
+++ b/test/encoding.test.ts
@@ -97,6 +97,10 @@ describe("encodeQueryValue", () => {
       input: String.raw`!@#$%^&*()_+{}[]|\:;<>,./?`,
       out: "!@%23$%25^%26*()_%2B%7B%7D%5B%5D|%5C:;%3C%3E,.%2F?",
     },
+    {
+      input: "a`b",
+      out: "a%60b",
+    },
   ];
 
   for (const t of tests) {


### PR DESCRIPTION
## Summary

Fixes #302

## Problem

`encodeQueryValue("a\`b")` returns `"a\`b"` instead of `"a%60b"`. Backticks are not being encoded in query values.

## Root Cause

The `encodeQueryValue()` function calls `encodeURI()` which correctly encodes backticks to `%60`, but then immediately **decodes** them back via:

```ts
.replace(ENC_BACKTICK_RE, "\`")  // %60 → `
```

This undoes the encoding, leaving literal backticks in the output.

## Fix

Remove the `.replace(ENC_BACKTICK_RE, "\`")` line from `encodeQueryValue()`. Backticks (`\`) are listed as unsafe characters in [RFC 1738 Section 2.2](https://datatracker.ietf.org/doc/html/rfc1738#section-2.2) and must be encoded in query string values.

## Changes

- `src/encoding.ts`: Remove ENC_BACKTICK_RE replacement (1 line)
- `test/encoding.test.ts`: Add test case for backtick encoding

## Test Plan

- [x] All 486 existing tests pass
- [x] New test: `encodeQueryValue("a\`b")` === "a%60b"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed improper handling of backtick characters in query parameters. Backticks are now correctly percent-encoded throughout the encoding process, ensuring consistent and reliable URL formatting and preventing potential parsing or compatibility issues when backticks appear in query string values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->