### PR TITLE
perf: make parseQuery ~40% faster

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "scripts": {
     "build": "automd && unbuild",
     "automd": "automd",
+    "benchmark": "jiti test/benchmark.ts",
     "dev": "vitest",
     "lint": "eslint . && prettier -c src test",
     "lint:fix": "eslint --fix . && prettier -w src test",

--- a/src/query.ts
+++ b/src/query.ts
@@ -27,6 +27,9 @@ const EQUAL_CHAR_CODE = 61;
 //   return C;
 // })() as unknown as { new (): any };
 
+/**
+ * Decodes and stores one parsed query parameter.
+ */
 function appendQueryParameter(
   object: ParsedQuery,
   key: string,

--- a/src/query.ts
+++ b/src/query.ts
@@ -18,11 +18,35 @@ export type QueryObject = Record<string, QueryValue | QueryValue[]>;
 
 export type ParsedQuery = Record<string, string | string[]>;
 
+const AMPERSAND_CHAR_CODE = 38;
+const EQUAL_CHAR_CODE = 61;
+
 // const EmptyObject = /* @__PURE__ */ (() => {
 //   const C = function () {};
 //   C.prototype = Object.create(null);
 //   return C;
 // })() as unknown as { new (): any };
+
+function appendQueryParameter(
+  object: ParsedQuery,
+  key: string,
+  value: string,
+): void {
+  key = decodeQueryKey(key);
+  if (key === "__proto__" || key === "constructor") {
+    return;
+  }
+
+  value = decodeQueryValue(value);
+  const currentValue = object[key];
+  if (currentValue === undefined) {
+    object[key] = value;
+  } else if (Array.isArray(currentValue)) {
+    currentValue.push(value);
+  } else {
+    object[key] = [currentValue, value];
+  }
+}
 
 /**
  * Parses and decodes a query string into an object.
@@ -50,25 +74,47 @@ export function parseQuery<T extends ParsedQuery = ParsedQuery>(
   // TODO: Use new EmptyObject() instead of Object.create(null) for better performance in next major version
   // https://github.com/unjs/ufo/pull/290
   const object: ParsedQuery = Object.create(null);
-  if (parametersString[0] === "?") {
-    parametersString = parametersString.slice(1);
-  }
-  for (const parameter of parametersString.split("&")) {
-    const s = parameter.match(/([^=]+)=?(.*)/) || [];
-    if (s.length < 2) {
+
+  let keyStart = -1;
+  let keyEnd = -1;
+  const stringLength = parametersString.length;
+
+  for (
+    let index = parametersString[0] === "?" ? 1 : 0;
+    index <= stringLength;
+    index++
+  ) {
+    const isEnd = index === stringLength;
+    const character = isEnd
+      ? AMPERSAND_CHAR_CODE
+      : parametersString.charCodeAt(index);
+
+    if (character === AMPERSAND_CHAR_CODE) {
+      if (keyStart !== -1) {
+        appendQueryParameter(
+          object,
+          parametersString.slice(keyStart, keyEnd === -1 ? index : keyEnd),
+          keyEnd === -1 ? "" : parametersString.slice(keyEnd + 1, index),
+        );
+      }
+      keyStart = -1;
+      keyEnd = -1;
       continue;
     }
-    const key = decodeQueryKey(s[1]);
-    if (key === "__proto__" || key === "constructor") {
+
+    if (character === EQUAL_CHAR_CODE) {
+      if (keyStart === -1) {
+        // Match the old unanchored regex: `=a=b` parses as `a=b`.
+        continue;
+      }
+      if (keyEnd === -1) {
+        keyEnd = index;
+      }
       continue;
     }
-    const value = decodeQueryValue(s[2] || "");
-    if (object[key] === undefined) {
-      object[key] = value;
-    } else if (Array.isArray(object[key])) {
-      (object[key] as string[]).push(value);
-    } else {
-      object[key] = [object[key] as string, value];
+
+    if (keyStart === -1) {
+      keyStart = index;
     }
   }
   return object as T;

--- a/test/benchmark.ts
+++ b/test/benchmark.ts
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+
+import { deepStrictEqual } from "node:assert";
+import { performance } from "node:perf_hooks";
+import { styleText } from "node:util";
+import {
+  decodeQueryKey,
+  decodeQueryValue,
+  parseQuery,
+  type ParsedQuery,
+} from "../src";
+
+const BENCHMARK_TIME_MS = readPositiveInteger("BENCHMARK_TIME_MS", 500);
+const WARMUP_TIME_MS = readPositiveInteger("BENCHMARK_WARMUP_MS", 100);
+const SAMPLE_COUNT = readPositiveInteger("BENCHMARK_SAMPLES", 3);
+const BATCH_SIZE = readPositiveInteger("BENCHMARK_BATCH_SIZE", 1000);
+
+type BenchmarkTask<TInput, TResult> = {
+  name: string;
+  run: (input: TInput) => TResult;
+};
+
+type BenchmarkCase<TInput> = {
+  name: string;
+  input: TInput;
+};
+
+type BenchmarkSuite<TInput, TResult> = {
+  name: string;
+  cases: Array<BenchmarkCase<TInput>>;
+  tasks: Array<BenchmarkTask<TInput, TResult>>;
+};
+
+type BenchmarkResult<TInput, TResult> = {
+  task: BenchmarkTask<TInput, TResult>;
+  samples: number[];
+  ops: number;
+};
+
+function readPositiveInteger(name: string, fallback: number): number {
+  const value = Number(process.env[name]);
+  return Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+function parseQueryBefore(parametersString = ""): ParsedQuery {
+  const object: ParsedQuery = Object.create(null);
+  if (parametersString[0] === "?") {
+    parametersString = parametersString.slice(1);
+  }
+  for (const parameter of parametersString.split("&")) {
+    const s = parameter.match(/([^=]+)=?(.*)/) || [];
+    if (s.length < 2) {
+      continue;
+    }
+
+    const key = decodeQueryKey(s[1]);
+    if (key === "__proto__" || key === "constructor") {
+      continue;
+    }
+
+    const value = decodeQueryValue(s[2] || "");
+    const currentValue = object[key];
+    if (currentValue === undefined) {
+      object[key] = value;
+    } else if (Array.isArray(currentValue)) {
+      currentValue.push(value);
+    } else {
+      object[key] = [currentValue, value];
+    }
+  }
+  return object;
+}
+
+let sink: unknown;
+let observedRuns = 0;
+
+function runFor(milliseconds: number, task: () => unknown): number {
+  const start = performance.now();
+  let iterations = 0;
+  let elapsed = 0;
+
+  do {
+    for (let index = 0; index < BATCH_SIZE; index++) {
+      sink = task();
+    }
+    iterations += BATCH_SIZE;
+    observedRuns += BATCH_SIZE;
+    elapsed = performance.now() - start;
+  } while (elapsed < milliseconds);
+
+  return (iterations / elapsed) * 1000;
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[middle - 1] + sorted[middle]) / 2
+    : sorted[middle];
+}
+
+function formatOps(value: number): string {
+  return value.toLocaleString("en-US", {
+    maximumFractionDigits: 0,
+  });
+}
+
+function assertSameResults<TInput, TResult>(
+  suite: BenchmarkSuite<TInput, TResult>,
+): void {
+  const [baseline, ...candidates] = suite.tasks;
+  if (!baseline) {
+    throw new Error(`${suite.name} has no benchmark tasks`);
+  }
+
+  for (const testCase of suite.cases) {
+    const expected = baseline.run(testCase.input);
+    for (const candidate of candidates) {
+      deepStrictEqual(
+        candidate.run(testCase.input),
+        expected,
+        `${suite.name}/${testCase.name}/${candidate.name}`,
+      );
+    }
+  }
+}
+
+function runCase<TInput, TResult>(
+  suite: BenchmarkSuite<TInput, TResult>,
+  testCase: BenchmarkCase<TInput>,
+): Array<BenchmarkResult<TInput, TResult>> {
+  const results = suite.tasks.map((task) => ({
+    task,
+    samples: [] as number[],
+    ops: 0,
+  }));
+
+  // Alternate task order to reduce first-run and branch-predictor bias.
+  for (let sampleIndex = 0; sampleIndex < SAMPLE_COUNT; sampleIndex++) {
+    const orderedResults =
+      sampleIndex % 2 === 0 ? results : [...results].reverse();
+
+    for (const result of orderedResults) {
+      const task = () => result.task.run(testCase.input);
+      runFor(WARMUP_TIME_MS, task);
+      result.samples.push(runFor(BENCHMARK_TIME_MS, task));
+    }
+  }
+
+  for (const result of results) {
+    result.ops = median(result.samples);
+  }
+  return results;
+}
+
+function runSuite<TInput, TResult>(
+  suite: BenchmarkSuite<TInput, TResult>,
+): void {
+  assertSameResults(suite);
+  process.stdout.write(`\n${styleText("bold", suite.name)}\n`);
+
+  const longestTaskName = Math.max(
+    ...suite.tasks.map((task) => task.name.length),
+  );
+
+  for (const testCase of suite.cases) {
+    const results = runCase(suite, testCase);
+    const baselineOps = results[0].ops;
+
+    process.stdout.write(`\n  ${testCase.name}\n`);
+    for (const result of results) {
+      const ratio = result.ops / baselineOps;
+      const ratioText =
+        result === results[0] ? "baseline" : `${ratio.toFixed(2)}x`;
+
+      process.stdout.write(
+        `  ${result.task.name.padEnd(longestTaskName)}  ${styleText(
+          "bold",
+          formatOps(result.ops).padStart(14),
+        )} ${styleText("dim", "ops/sec")}  ${ratioText}\n`,
+      );
+    }
+  }
+}
+
+const longQuery = Array.from(
+  { length: 50 },
+  (_, index) => `key${index}=value%20${index}`,
+).join("&");
+
+const parseQuerySuite: BenchmarkSuite<string, ParsedQuery> = {
+  name: "parseQuery",
+  tasks: [
+    {
+      name: "before (split + regex)",
+      run: parseQueryBefore,
+    },
+    {
+      name: "after  (single pass)",
+      run: parseQuery,
+    },
+  ],
+  cases: [
+    {
+      name: "empty",
+      input: "",
+    },
+    {
+      name: "single pair",
+      input: "a=1",
+    },
+    {
+      name: "mixed pairs",
+      input: "foo=bar&baz=qux&unicode=%E5%A5%BD",
+    },
+    {
+      name: "repeated keys",
+      input: "tag=a&tag=b&tag=c",
+    },
+    {
+      name: "encoded value",
+      input: "param=%7B%22a%22:%5B1,2,3%5D%7D&x=1",
+    },
+    {
+      name: "leading equals",
+      input: "=foo=bar&==baz=qux&===",
+    },
+    {
+      name: "long",
+      input: longQuery,
+    },
+  ],
+};
+
+runSuite(parseQuerySuite);
+
+if (observedRuns === 0) {
+  process.exitCode = 1;
+}
+void sink;

--- a/test/benchmark.ts
+++ b/test/benchmark.ts
@@ -1,24 +1,13 @@
 #!/usr/bin/env node
 
-import { deepStrictEqual } from "node:assert";
 import { performance } from "node:perf_hooks";
 import { styleText } from "node:util";
-import {
-  decodeQueryKey,
-  decodeQueryValue,
-  parseQuery,
-  type ParsedQuery,
-} from "../src";
+import { parseQuery, type ParsedQuery } from "../src";
 
 const BENCHMARK_TIME_MS = readPositiveInteger("BENCHMARK_TIME_MS", 500);
 const WARMUP_TIME_MS = readPositiveInteger("BENCHMARK_WARMUP_MS", 100);
 const SAMPLE_COUNT = readPositiveInteger("BENCHMARK_SAMPLES", 3);
 const BATCH_SIZE = readPositiveInteger("BENCHMARK_BATCH_SIZE", 1000);
-
-type BenchmarkTask<TInput, TResult> = {
-  name: string;
-  run: (input: TInput) => TResult;
-};
 
 type BenchmarkCase<TInput> = {
   name: string;
@@ -28,11 +17,10 @@ type BenchmarkCase<TInput> = {
 type BenchmarkSuite<TInput, TResult> = {
   name: string;
   cases: Array<BenchmarkCase<TInput>>;
-  tasks: Array<BenchmarkTask<TInput, TResult>>;
+  run: (input: TInput) => TResult;
 };
 
-type BenchmarkResult<TInput, TResult> = {
-  task: BenchmarkTask<TInput, TResult>;
+type BenchmarkResult = {
   samples: number[];
   ops: number;
 };
@@ -42,36 +30,8 @@ function readPositiveInteger(name: string, fallback: number): number {
   return Number.isInteger(value) && value > 0 ? value : fallback;
 }
 
-function parseQueryBefore(parametersString = ""): ParsedQuery {
-  const object: ParsedQuery = Object.create(null);
-  if (parametersString[0] === "?") {
-    parametersString = parametersString.slice(1);
-  }
-  for (const parameter of parametersString.split("&")) {
-    const s = parameter.match(/([^=]+)=?(.*)/) || [];
-    if (s.length < 2) {
-      continue;
-    }
-
-    const key = decodeQueryKey(s[1]);
-    if (key === "__proto__" || key === "constructor") {
-      continue;
-    }
-
-    const value = decodeQueryValue(s[2] || "");
-    const currentValue = object[key];
-    if (currentValue === undefined) {
-      object[key] = value;
-    } else if (Array.isArray(currentValue)) {
-      currentValue.push(value);
-    } else {
-      object[key] = [currentValue, value];
-    }
-  }
-  return object;
-}
-
-let sink: unknown;
+const EMPTY_SINK = Symbol("empty-sink");
+let sink: unknown = EMPTY_SINK;
 let observedRuns = 0;
 
 function runFor(milliseconds: number, task: () => unknown): number {
@@ -105,81 +65,42 @@ function formatOps(value: number): string {
   });
 }
 
-function assertSameResults<TInput, TResult>(
-  suite: BenchmarkSuite<TInput, TResult>,
-): void {
-  const [baseline, ...candidates] = suite.tasks;
-  if (!baseline) {
-    throw new Error(`${suite.name} has no benchmark tasks`);
-  }
-
-  for (const testCase of suite.cases) {
-    const expected = baseline.run(testCase.input);
-    for (const candidate of candidates) {
-      deepStrictEqual(
-        candidate.run(testCase.input),
-        expected,
-        `${suite.name}/${testCase.name}/${candidate.name}`,
-      );
-    }
-  }
-}
-
 function runCase<TInput, TResult>(
   suite: BenchmarkSuite<TInput, TResult>,
   testCase: BenchmarkCase<TInput>,
-): Array<BenchmarkResult<TInput, TResult>> {
-  const results = suite.tasks.map((task) => ({
-    task,
-    samples: [] as number[],
+): BenchmarkResult {
+  const result: BenchmarkResult = {
+    samples: [],
     ops: 0,
-  }));
+  };
 
-  // Alternate task order to reduce first-run and branch-predictor bias.
   for (let sampleIndex = 0; sampleIndex < SAMPLE_COUNT; sampleIndex++) {
-    const orderedResults =
-      sampleIndex % 2 === 0 ? results : [...results].reverse();
-
-    for (const result of orderedResults) {
-      const task = () => result.task.run(testCase.input);
-      runFor(WARMUP_TIME_MS, task);
-      result.samples.push(runFor(BENCHMARK_TIME_MS, task));
-    }
+    const task = () => suite.run(testCase.input);
+    runFor(WARMUP_TIME_MS, task);
+    result.samples.push(runFor(BENCHMARK_TIME_MS, task));
   }
 
-  for (const result of results) {
-    result.ops = median(result.samples);
-  }
-  return results;
+  result.ops = median(result.samples);
+  return result;
 }
 
 function runSuite<TInput, TResult>(
   suite: BenchmarkSuite<TInput, TResult>,
 ): void {
-  assertSameResults(suite);
   process.stdout.write(`\n${styleText("bold", suite.name)}\n`);
 
-  const longestTaskName = Math.max(
-    ...suite.tasks.map((task) => task.name.length),
+  const longestCaseName = Math.max(
+    ...suite.cases.map((testCase) => testCase.name.length),
   );
 
   for (const testCase of suite.cases) {
-    const results = runCase(suite, testCase);
-    const baselineOps = results[0].ops;
-
-    process.stdout.write(`\n  ${testCase.name}\n`);
-    for (const result of results) {
-      const ratio = result.ops / baselineOps;
-      const ratioText =
-        result === results[0] ? "baseline" : `${ratio.toFixed(2)}x`;
-
-      process.stdout.write(
-        `  ${result.task.name.padEnd(longestTaskName)}  ${styleText(
-          "bold",
-          formatOps(result.ops).padStart(14),
-        )} ${styleText("dim", "ops/sec")}  ${ratioText}\n`,
-      );
-    }
+    const result = runCase(suite, testCase);
+    process.stdout.write(
+      `${testCase.name.padEnd(longestCaseName)}  ${styleText(
+        "bold",
+        formatOps(result.ops).padStart(14),
+      )} ${styleText("dim", "ops/sec")}\n`,
+    );
   }
 }
 
@@ -190,16 +111,7 @@ const longQuery = Array.from(
 
 const parseQuerySuite: BenchmarkSuite<string, ParsedQuery> = {
   name: "parseQuery",
-  tasks: [
-    {
-      name: "before (split + regex)",
-      run: parseQueryBefore,
-    },
-    {
-      name: "after  (single pass)",
-      run: parseQuery,
-    },
-  ],
+  run: parseQuery,
   cases: [
     {
       name: "empty",
@@ -234,7 +146,6 @@ const parseQuerySuite: BenchmarkSuite<string, ParsedQuery> = {
 
 runSuite(parseQuerySuite);
 
-if (observedRuns === 0) {
+if (observedRuns === 0 || sink === EMPTY_SINK) {
   process.exitCode = 1;
 }
-void sink;

--- a/test/benchmark.ts
+++ b/test/benchmark.ts
@@ -25,6 +25,9 @@ type BenchmarkResult = {
   ops: number;
 };
 
+/**
+ * Reads a positive integer from the environment.
+ */
 function readPositiveInteger(name: string, fallback: number): number {
   const value = Number(process.env[name]);
   return Number.isInteger(value) && value > 0 ? value : fallback;
@@ -34,6 +37,9 @@ const EMPTY_SINK = Symbol("empty-sink");
 let sink: unknown = EMPTY_SINK;
 let observedRuns = 0;
 
+/**
+ * Runs a task for the requested duration and returns ops/sec.
+ */
 function runFor(milliseconds: number, task: () => unknown): number {
   const start = performance.now();
   let iterations = 0;
@@ -51,6 +57,9 @@ function runFor(milliseconds: number, task: () => unknown): number {
   return (iterations / elapsed) * 1000;
 }
 
+/**
+ * Returns the median sample value.
+ */
 function median(values: number[]): number {
   const sorted = [...values].sort((a, b) => a - b);
   const middle = Math.floor(sorted.length / 2);
@@ -59,12 +68,18 @@ function median(values: number[]): number {
     : sorted[middle];
 }
 
+/**
+ * Formats ops/sec for benchmark output.
+ */
 function formatOps(value: number): string {
   return value.toLocaleString("en-US", {
     maximumFractionDigits: 0,
   });
 }
 
+/**
+ * Benchmarks one input case with warmup and repeated samples.
+ */
 function runCase<TInput, TResult>(
   suite: BenchmarkSuite<TInput, TResult>,
   testCase: BenchmarkCase<TInput>,
@@ -84,6 +99,9 @@ function runCase<TInput, TResult>(
   return result;
 }
 
+/**
+ * Prints benchmark results for a utility suite.
+ */
 function runSuite<TInput, TResult>(
   suite: BenchmarkSuite<TInput, TResult>,
 ): void {

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { filterQuery, getQuery, withQuery } from "../src";
+import { filterQuery, getQuery, parseQuery, withQuery } from "../src";
 
 describe("withQuery", () => {
   const tests = [
@@ -70,6 +70,52 @@ describe("withQuery", () => {
       expect(withQuery(t.input, t.query)).toBe(t.out);
     });
   }
+});
+
+describe("parseQuery", () => {
+  test("parses repeated keys into arrays", () => {
+    const query = parseQuery("tags=javascript&tags=web&tags=dev");
+
+    expect(query.tags).toEqual(["javascript", "web", "dev"]);
+  });
+
+  test("parses empty values and values containing equals", () => {
+    const query = parseQuery("?empty=&flag&param=a=b=c");
+
+    expect(query.empty).toBe("");
+    expect(query.flag).toBe("");
+    expect(query.param).toBe("a=b=c");
+  });
+
+  test("decodes plus and invalid percent sequences like encoding helpers", () => {
+    const query = parseQuery("key+with+space=value+with+space&bad=%E0%A4%A");
+
+    expect(query["key with space"]).toBe("value with space");
+    expect(query.bad).toBe("%E0%A4%A");
+  });
+
+  test("ignores dangerous keys and returns a null-prototype object", () => {
+    const query = parseQuery(
+      "__proto__=polluted&%5F%5Fproto%5F%5F=encoded&constructor=evil&safe=ok",
+    );
+
+    expect(Object.getPrototypeOf(query)).toBe(null);
+    expect(Object.prototype.hasOwnProperty.call(query, "__proto__")).toBe(
+      false,
+    );
+    expect(Object.prototype.hasOwnProperty.call(query, "constructor")).toBe(
+      false,
+    );
+    expect(query.safe).toBe("ok");
+  });
+
+  test("preserves leading equals compatibility", () => {
+    const query = parseQuery("=foo=bar&==baz=qux&===");
+
+    expect(query.foo).toBe("bar");
+    expect(query.baz).toBe("qux");
+    expect(Object.keys(query)).toEqual(["foo", "baz"]);
+  });
 });
 
 describe("filterQuery", () => {


### PR DESCRIPTION
## Summary

Resolves #330

Improves `parseQuery` performance while preserving existing behavior.

Local benchmarks show non-empty query parsing is about **40% faster on average**, with larger gains for smaller query strings.

## Changes

- Optimize `parseQuery` internals
- Preserve compatibility for existing edge cases
- Add focused tests for parsing behavior and pollution guards
- Add a reusable `pnpm benchmark` script

## Benchmark

Local median ops/sec from `pnpm benchmark`:

| Case | Current | Optimized | Change | Speedup |
|---|---:|---:|---:|---:|
| empty | 15,480,771 | 80,642,508 | +65,161,737 | +421% |
| single pair | 3,625,934 | 6,222,686 | +2,596,752 | +72% |
| mixed pairs | 942,334 | 1,281,652 | +339,318 | +36% |
| repeated keys | 1,078,305 | 1,547,175 | +468,870 | +43% |
| encoded value | 1,414,185 | 1,864,394 | +450,209 | +32% |
| leading equals | 1,357,922 | 1,856,343 | +498,421 | +37% |
| long | 48,814 | 59,466 | +10,652 | +22% |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a benchmarking tool to measure query-parsing performance.

* **Bug Fixes**
  * Improved parsing for repeated keys, empty values, leading-equals keys, and special-character cases.

* **Security**
  * Now ignores prototype-pollution keys and returns a null-prototype result object.

* **Performance**
  * Query parsing optimized for higher throughput.

* **Tests**
  * Expanded tests covering parsing semantics and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->