### PR TITLE
perf: make stringifyQuery ~3% faster

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -132,7 +132,7 @@ export function encodeQueryItem(
 export function stringifyQuery(query: QueryObject): string {
   let stringifiedQuery = "";
   for (const key in query) {
-    if (!Object.prototype.hasOwnProperty.call(query, key)) {
+    if (!Object.hasOwn(query, key)) {
       continue;
     }
     const value = query[key];

--- a/src/query.ts
+++ b/src/query.ts
@@ -130,9 +130,19 @@ export function encodeQueryItem(
  * @group Query_utils
  */
 export function stringifyQuery(query: QueryObject): string {
-  return Object.keys(query)
-    .filter((k) => query[k] !== undefined)
-    .map((k) => encodeQueryItem(k, query[k]))
-    .filter(Boolean)
-    .join("&");
+  let stringifiedQuery = "";
+  for (const key in query) {
+    if (!Object.prototype.hasOwnProperty.call(query, key)) {
+      continue;
+    }
+    const value = query[key];
+    if (value === undefined) {
+      continue;
+    }
+    const queryItem = encodeQueryItem(key, value);
+    if (queryItem) {
+      stringifiedQuery += stringifiedQuery ? `&${queryItem}` : queryItem;
+    }
+  }
+  return stringifiedQuery;
 }


### PR DESCRIPTION
### What changed

Optimized `stringifyQuery` to build the query string in one pass instead of chaining multiple array methods.

Closes https://github.com/unjs/ufo/issues/332

### Perf

[Perf.link](https://perf.link/#eyJpZCI6InN0cmluZ2lmeS1vYmplY3QtaGFzLW93biIsInRpdGxlIjoic3RyaW5naWZ5UXVlcnkgb25lLXdheSBpdGVyYXRpb24gd2l0aCBPYmplY3QuaGFzT3duIiwiYmVmb3JlIjoiY29uc3QgSEFTSF9SRSA9IC8jL2c7XG5jb25zdCBBTVBFUlNBTkRfUkUgPSAvJi9nO1xuY29uc3QgU0xBU0hfUkUgPSAvXFwvL2c7XG5jb25zdCBFUVVBTF9SRSA9IC89L2c7XG5jb25zdCBQTFVTX1JFID0gL1xcKy9nO1xuY29uc3QgRU5DX0NBUkVUX1JFID0gLyU1ZS9naTtcbmNvbnN0IEVOQ19CQUNLVElDS19SRSA9IC8lNjAvZ2k7XG5jb25zdCBFTkNfUElQRV9SRSA9IC8lN2MvZ2k7XG5jb25zdCBFTkNfU1BBQ0VfUkUgPSAvJTIwL2dpO1xuXG5mdW5jdGlvbiBlbmNvZGUodGV4dCkge1xuICByZXR1cm4gZW5jb2RlVVJJKFN0cmluZyh0ZXh0KSkucmVwbGFjZShFTkNfUElQRV9SRSwgXCJ8XCIpO1xufVxuXG5mdW5jdGlvbiBlbmNvZGVRdWVyeVZhbHVlKGlucHV0KSB7XG4gIGNvbnN0IHRleHQgPSB0eXBlb2YgaW5wdXQgPT09IFwic3RyaW5nXCIgPyBpbnB1dCA6IEpTT04uc3RyaW5naWZ5KGlucHV0KTtcbiAgcmV0dXJuIGVuY29kZSh0ZXh0KVxuICAgIC5yZXBsYWNlKFBMVVNfUkUsIFwiJTJCXCIpXG4gICAgLnJlcGxhY2UoRU5DX1NQQUNFX1JFLCBcIitcIilcbiAgICAucmVwbGFjZShIQVNIX1JFLCBcIiUyM1wiKVxuICAgIC5yZXBsYWNlKEFNUEVSU0FORF9SRSwgXCIlMjZcIilcbiAgICAucmVwbGFjZShFTkNfQkFDS1RJQ0tfUkUsIFN0cmluZy5mcm9tQ2hhckNvZGUoOTYpKVxuICAgIC5yZXBsYWNlKEVOQ19DQVJFVF9SRSwgXCJeXCIpXG4gICAgLnJlcGxhY2UoU0xBU0hfUkUsIFwiJTJGXCIpO1xufVxuXG5mdW5jdGlvbiBlbmNvZGVRdWVyeUtleSh0ZXh0KSB7XG4gIHJldHVybiBlbmNvZGVRdWVyeVZhbHVlKHRleHQpLnJlcGxhY2UoRVFVQUxfUkUsIFwiJTNEXCIpO1xufVxuXG5mdW5jdGlvbiBlbmNvZGVRdWVyeUl0ZW0oa2V5LCB2YWx1ZSkge1xuICBpZiAodHlwZW9mIHZhbHVlID09PSBcIm51bWJlclwiIHx8IHR5cGVvZiB2YWx1ZSA9PT0gXCJib29sZWFuXCIpIHtcbiAgICB2YWx1ZSA9IFN0cmluZyh2YWx1ZSk7XG4gIH1cbiAgaWYgKCF2YWx1ZSkge1xuICAgIHJldHVybiBlbmNvZGVRdWVyeUtleShrZXkpO1xuICB9XG4gIGlmIChBcnJheS5pc0FycmF5KHZhbHVlKSkge1xuICAgIHJldHVybiB2YWx1ZVxuICAgICAgLm1hcCgoaXRlbSkgPT4gZW5jb2RlUXVlcnlLZXkoa2V5KSArIFwiPVwiICsgZW5jb2RlUXVlcnlWYWx1ZShpdGVtKSlcbiAgICAgIC5qb2luKFwiJlwiKTtcbiAgfVxuICByZXR1cm4gZW5jb2RlUXVlcnlLZXkoa2V5KSArIFwiPVwiICsgZW5jb2RlUXVlcnlWYWx1ZSh2YWx1ZSk7XG59XG5cbmZ1bmN0aW9uIG9sZFN0cmluZ2lmeVF1ZXJ5KHF1ZXJ5KSB7XG4gIHJldHVybiBPYmplY3Qua2V5cyhxdWVyeSlcbiAgICAuZmlsdGVyKChrZXkpID0%2BIHF1ZXJ5W2tleV0gIT09IHVuZGVmaW5lZClcbiAgICAubWFwKChrZXkpID0%2BIGVuY29kZVF1ZXJ5SXRlbShrZXksIHF1ZXJ5W2tleV0pKVxuICAgIC5maWx0ZXIoQm9vbGVhbilcbiAgICAuam9pbihcIiZcIik7XG59XG5cbmZ1bmN0aW9uIG5ld1N0cmluZ2lmeVF1ZXJ5KHF1ZXJ5KSB7XG4gIGxldCBzdHJpbmdpZmllZFF1ZXJ5ID0gXCJcIjtcbiAgZm9yIChjb25zdCBrZXkgaW4gcXVlcnkpIHtcbiAgICBpZiAoIU9iamVjdC5oYXNPd24ocXVlcnksIGtleSkpIHtcbiAgICAgIGNvbnRpbnVlO1xuICAgIH1cbiAgICBjb25zdCB2YWx1ZSA9IHF1ZXJ5W2tleV07XG4gICAgaWYgKHZhbHVlID09PSB1bmRlZmluZWQpIHtcbiAgICAgIGNvbnRpbnVlO1xuICAgIH1cbiAgICBjb25zdCBxdWVyeUl0ZW0gPSBlbmNvZGVRdWVyeUl0ZW0oa2V5LCB2YWx1ZSk7XG4gICAgaWYgKHF1ZXJ5SXRlbSkge1xuICAgICAgc3RyaW5naWZpZWRRdWVyeSArPSBzdHJpbmdpZmllZFF1ZXJ5ID8gXCImXCIgKyBxdWVyeUl0ZW0gOiBxdWVyeUl0ZW07XG4gICAgfVxuICB9XG4gIHJldHVybiBzdHJpbmdpZmllZFF1ZXJ5O1xufVxuXG5mdW5jdGlvbiBnZXRRdWVyeVZhbHVlKGluZGV4KSB7XG4gIGlmIChpbmRleCAlIDExID09PSAwKSB7XG4gICAgcmV0dXJuIHVuZGVmaW5lZDtcbiAgfVxuICBpZiAoaW5kZXggJSA3ID09PSAwKSB7XG4gICAgcmV0dXJuIFtTdHJpbmcoaW5kZXgpLCBcIlwiLCB0cnVlXTtcbiAgfVxuICBpZiAoaW5kZXggJSA1ID09PSAwKSB7XG4gICAgcmV0dXJuIG51bGw7XG4gIH1cbiAgcmV0dXJuIFwidmFsdWUgXCIgKyBpbmRleDtcbn1cblxuZnVuY3Rpb24gbWFrZVF1ZXJ5KHNpemUpIHtcbiAgY29uc3QgcXVlcnkgPSB7fTtcbiAgZm9yIChsZXQgaW5kZXggPSAwOyBpbmRleCA8IHNpemU7IGluZGV4KyspIHtcbiAgICBxdWVyeVtcImtleSBcIiArIGluZGV4XSA9IGdldFF1ZXJ5VmFsdWUoaW5kZXgpO1xuICB9XG4gIHJldHVybiBxdWVyeTtcbn1cblxuY29uc3QgcXVlcnkyNSA9IG1ha2VRdWVyeSgyNSk7XG5jb25zdCBxdWVyeTEwMCA9IG1ha2VRdWVyeSgxMDApO1xuY29uc3QgcXVlcnk1MDAgPSBtYWtlUXVlcnkoNTAwKTtcblxuaWYgKFxuICBvbGRTdHJpbmdpZnlRdWVyeShxdWVyeTI1KSAhPT0gbmV3U3RyaW5naWZ5UXVlcnkocXVlcnkyNSkgfHxcbiAgb2xkU3RyaW5naWZ5UXVlcnkocXVlcnkxMDApICE9PSBuZXdTdHJpbmdpZnlRdWVyeShxdWVyeTEwMCkgfHxcbiAgb2xkU3RyaW5naWZ5UXVlcnkocXVlcnk1MDApICE9PSBuZXdTdHJpbmdpZnlRdWVyeShxdWVyeTUwMClcbikge1xuICB0aHJvdyBuZXcgRXJyb3IoXCJtaXNtYXRjaFwiKTtcbn0iLCJ0ZXN0cyI6W3sibmFtZSI6Im9sZCBjaGFpbiAoMjUga2V5cykiLCJjb2RlIjoib2xkU3RyaW5naWZ5UXVlcnkocXVlcnkyNSkiLCJvcHMiOjc2NTk4fSx7Im5hbWUiOiJuZXcgb25lLWxvb3AgT2JqZWN0Lmhhc093biAoMjUga2V5cykiLCJjb2RlIjoibmV3U3RyaW5naWZ5UXVlcnkocXVlcnkyNSkiLCJvcHMiOjc4MDY1fSx7Im5hbWUiOiJvbGQgY2hhaW4gKDEwMCBrZXlzKSIsImNvZGUiOiJvbGRTdHJpbmdpZnlRdWVyeShxdWVyeTEwMCkiLCJvcHMiOjE4NTE4fSx7Im5hbWUiOiJuZXcgb25lLWxvb3AgT2JqZWN0Lmhhc093biAoMTAwIGtleXMpIiwiY29kZSI6Im5ld1N0cmluZ2lmeVF1ZXJ5KHF1ZXJ5MTAwKSIsIm9wcyI6MTkxNDB9LHsibmFtZSI6Im9sZCBjaGFpbiAoNTAwIGtleXMpIiwiY29kZSI6Im9sZFN0cmluZ2lmeVF1ZXJ5KHF1ZXJ5NTAwKSIsIm9wcyI6MzUzM30seyJuYW1lIjoibmV3IG9uZS1sb29wIE9iamVjdC5oYXNPd24gKDUwMCBrZXlzKSIsImNvZGUiOiJuZXdTdHJpbmdpZnlRdWVyeShxdWVyeTUwMCkiLCJvcHMiOjM2MzN9XSwidXBkYXRlZCI6IjIwMjYtMDQtMjZUMDU6NTA6MzIuNDU2WiJ9)

- 25 keys: `76,598 ops/s` -> `78,065 ops/s` (`+1.92%`)
- 100 keys: `18,518 ops/s` -> `19,140 ops/s` (`+3.36%`)
- 500 keys: `3,533 ops/s` -> `3,633 ops/s` (`+2.83%`)
- summed ops: `98,649 ops/s` -> `100,838 ops/s` (`+2.22%`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal rewrite of query string construction for improved maintainability and clarity.
  * No changes to public behavior or API; end-user experience remains the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->