### PR TITLE
fix(withProtocol): preserve host when adding protocol to host ports

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,7 +12,7 @@ const PROTOCOL_STRICT_REGEX = /^[\s\w\0+.-]{2,}:([/\\]{1,2})/;
 const PROTOCOL_REGEX = /^[\s\w\0+.-]{2,}:([/\\]{2})?/;
 const PROTOCOL_RELATIVE_REGEX = /^([/\\]\s*){2,}[^/\\]/;
 const PROTOCOL_SCRIPT_RE = /^[\s\0]*(blob|data|javascript|vbscript):$/i;
-const HOST_PORT_RE = /^[^\s:/?#\\]+:\d+(?:[/?#]|$)/;
+const HOST_PORT_RE = /^[\s\0]*[^\s:/?#\\]+:\d+(?:[/?#]|$)/;
 const NON_SLASH_PROTOCOL_RE =
   /^(?:blob|data|javascript|vbscript|mailto|tel|sms|urn|skype|callto):/i;
 const TRAILING_SLASH_RE = /\/$|\/\?|\/#/;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,6 +12,9 @@ const PROTOCOL_STRICT_REGEX = /^[\s\w\0+.-]{2,}:([/\\]{1,2})/;
 const PROTOCOL_REGEX = /^[\s\w\0+.-]{2,}:([/\\]{2})?/;
 const PROTOCOL_RELATIVE_REGEX = /^([/\\]\s*){2,}[^/\\]/;
 const PROTOCOL_SCRIPT_RE = /^[\s\0]*(blob|data|javascript|vbscript):$/i;
+const HOST_PORT_RE = /^[^\s:/?#\\]+:\d+(?:[/?#]|$)/;
+const NON_SLASH_PROTOCOL_RE =
+  /^(?:blob|data|javascript|vbscript|mailto|tel|sms|urn|skype|callto):/i;
 const TRAILING_SLASH_RE = /\/$|\/\?|\/#/;
 const JOIN_LEADING_SLASH_RE = /^\.?\//;
 
@@ -564,6 +567,13 @@ export function withoutProtocol(input: string): string {
  */
 export function withProtocol(input: string, protocol: string): string {
   let match = input.match(PROTOCOL_REGEX);
+  if (
+    match?.[0].endsWith(":") &&
+    HOST_PORT_RE.test(input) &&
+    !NON_SLASH_PROTOCOL_RE.test(input)
+  ) {
+    match = null;
+  }
   if (!match) {
     match = input.match(/^\/{2,}/);
   }

--- a/test/utilities.test.ts
+++ b/test/utilities.test.ts
@@ -145,6 +145,7 @@ describe("withHttp", () => {
     },
     { input: "file:///home/user", out: "http:///home/user" },
     { input: "foo.bar.com", out: "http://foo.bar.com" },
+    { input: "localhost:9000", out: "http://localhost:9000" },
   ];
 
   for (const t of tests) {
@@ -167,6 +168,7 @@ describe("withHttps", () => {
     },
     { input: "file:///home/user", out: "https:///home/user" },
     { input: "foo.bar.com", out: "https://foo.bar.com" },
+    { input: "localhost:9000", out: "https://localhost:9000" },
   ];
 
   for (const t of tests) {
@@ -224,6 +226,16 @@ describe("withProtocol", () => {
       protocol: "callto://",
       out: "callto://+1234567890",
     },
+    {
+      input: "localhost:9000",
+      protocol: "ftp://",
+      out: "ftp://localhost:9000",
+    },
+    {
+      input: "api-service:9000/path?query=1#hash",
+      protocol: "http://",
+      out: "http://api-service:9000/path?query=1#hash",
+    },
   ];
 
   for (const t of tests) {
@@ -238,6 +250,7 @@ describe("withoutProtocol", () => {
     { input: "http://example.com", out: "example.com" },
     { input: "https://example.com", out: "example.com" },
     { input: "ftp://example.com/test?foo", out: "example.com/test?foo" },
+    { input: "localhost:9000", out: "localhost:9000" },
     {
       input: "http://foo.com/test?query=123#hash",
       out: "foo.com/test?query=123#hash",

--- a/test/utilities.test.ts
+++ b/test/utilities.test.ts
@@ -232,6 +232,16 @@ describe("withProtocol", () => {
       out: "ftp://localhost:9000",
     },
     {
+      input: " localhost:9000",
+      protocol: "http://",
+      out: "http:// localhost:9000",
+    },
+    {
+      input: "\0localhost:9000",
+      protocol: "http://",
+      out: "http://\0localhost:9000",
+    },
+    {
       input: "api-service:9000/path?query=1#hash",
       protocol: "http://",
       out: "http://api-service:9000/path?query=1#hash",


### PR DESCRIPTION
### Linked issue

Fixes #237

### Type of change

- [x] Bug fix
- [x] Tests

### Description

`withProtocol()` currently treats `localhost:9000` as if `localhost:` were a protocol because the loose protocol matcher accepts colon-only schemes. This drops the host and returns `http://9000`.

This change detects host:port inputs before stripping a matched colon-only scheme, so helpers like `withHttp()`, `withHttps()`, `withProtocol()`, and `withoutProtocol()` preserve the full host:port value. Existing colon-only URL schemes such as `tel:` and `callto:` keep their current behavior.

###  Tests

- `pnpm exec vitest run test/utilities.test.ts`
- `pnpm exec vitest run --typecheck`
- `pnpm exec eslint .`
- `pnpm exec prettier -c src/utils.ts test/utilities.test.ts`
- `pnpm build`
- `git diff --check`

Note: `pnpm lint` runs the full repository Prettier check, which reports existing line-ending/style differences in this Windows checkout. The touched files pass Prettier directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed protocol detection that could misinterpret host:port inputs (e.g., localhost:9000), preventing incorrect prefix removal and ensuring correct protocol prefixing.

* **Tests**
  * Expanded test coverage for host:port and complex URL forms across different protocols and edge cases (leading whitespace, NUL char, paths, queries, and hashes) to verify consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->