### PR TITLE
fix(withoutBase): collapse leading slashes

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -328,8 +328,10 @@ export function withoutBase(input: string, base: string) {
   if (nextChar && nextChar !== "/" && nextChar !== "?") {
     return input;
   }
-  const trimmed = input.slice(_base.length);
-  return trimmed[0] === "/" ? trimmed : "/" + trimmed;
+  // Collapse leading slashes to prevent protocol-relative URL injection
+  // e.g. withoutBase("/legacy//evil.com", "/legacy") must not return "//evil.com"
+  const trimmed = input.slice(_base.length).replace(/^\/+/, "");
+  return "/" + trimmed;
 }
 
 /**

--- a/test/base.test.ts
+++ b/test/base.test.ts
@@ -62,6 +62,11 @@ describe("withoutBase", () => {
     },
     { base: "/admin", input: "/admin-dashboard", out: "/admin-dashboard" },
     { base: "/admin/", input: "/admin/dashboard", out: "/dashboard" },
+    // Collapse leading "//" to prevent protocol-relative URL injection
+    { base: "/legacy", input: "/legacy//evil.com", out: "/evil.com" },
+    { base: "/legacy/", input: "/legacy//evil.com", out: "/evil.com" },
+    { base: "/legacy", input: "/legacy///evil.com", out: "/evil.com" },
+    { base: "/legacy", input: "/legacy//", out: "/" },
   ];
 
   for (const t of tests) {


### PR DESCRIPTION
slicing the base prefix from inputs like `/legacy//evil.com` left the
remainder as `//evil.com`, which browsers interpret as a protocol-relative
URL. This enabled an open redirect when consumers (e.g. nitro route rules)
fed the result into a redirect Location header.

Normalize all leading slashes on the trimmed remainder so the output is
always a single-host-relative path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced path sanitization to prevent potential security vulnerabilities with protocol-relative URLs. Malformed paths containing repeated leading slashes are now safely normalized to relative path formats.

* **Tests**
  * Added test coverage for edge cases with repeated leading slashes in paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->