### PR TITLE
fix(parseQuery): treat keys ending with [] as arrays

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -37,6 +37,9 @@ export type ParsedQuery = Record<string, string | string[]>;
  *
  * parseQuery("tags=javascript&tags=web&tags=dev");
  * // { tags: ["javascript", "web", "dev"] }
+ *
+ * parseQuery("filter[size][]=large");
+ * // { "filter[size]": ["large"] }
  * ```
  *
  * @note
@@ -63,12 +66,14 @@ export function parseQuery<T extends ParsedQuery = ParsedQuery>(
       continue;
     }
     const value = decodeQueryValue(s[2] || "");
-    if (object[key] === undefined) {
-      object[key] = value;
-    } else if (Array.isArray(object[key])) {
-      (object[key] as string[]).push(value);
+    const arrayKey = key.endsWith("[]");
+    const storageKey = arrayKey ? key.slice(0, -2) : key;
+    if (object[storageKey] === undefined) {
+      object[storageKey] = arrayKey ? [value] : value;
+    } else if (Array.isArray(object[storageKey])) {
+      (object[storageKey] as string[]).push(value);
     } else {
-      object[key] = [object[key] as string, value];
+      object[storageKey] = [object[storageKey] as string, value];
     }
   }
   return object as T;

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -101,6 +101,12 @@ describe("getQuery", () => {
       param: '{"a":[{"obj":[1,2,3]}]}',
     },
     "http://foo.com/?toString=foo": { toString: "foo" },
+    "http://foo.com/?filter[size][]=large": { "filter[size]": ["large"] },
+    "http://foo.com/?filter[size]=large": { "filter[size]": "large" },
+    "http://foo.com/?filter[size][]=large&filter[size][]=medium": {
+      "filter[size]": ["large", "medium"],
+    },
+    "http://foo.com/?foo[]=bar": { foo: ["bar"] },
   };
 
   for (const t in tests) {


### PR DESCRIPTION
## Summary

- When a query key ends with `[]` (PHP-style array notation), `parseQuery` now stores the value as an array even for a single entry
- Keys without the `[]` suffix keep returning a string value

## Example

```js
parseQuery("filter[size][]=large");
// { "filter[size]": ["large"] }

parseQuery("filter[size]=large");
// { "filter[size]": "large" }
```

Fixes #296

## Test plan

- [x] `pnpm test` passes (495 tests)
- [x] Added `getQuery` regression cases for single/multiple `[]` keys and plain keys

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query parameter parsing to correctly handle nested bracket-based parameters (e.g., `filter[size][]`).
  * Enhanced support for array-marked parameters to properly distinguish between single values and multiple accumulated values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/ufo/pull/341?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->