### PR TITLE
feat: add withoutQuery utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,16 @@ Removes the query section of the URL.
 filterQuery("/foo?bar=1&baz=2", (key) => key !== "bar"); // "/foo?baz=2"
 ```
 
+### `withoutQuery(input)`
+
+Removes the entire query section of the URL.
+
+**Example:**
+
+```js
+withoutQuery("/foo?bar=1&baz=2"); // "/foo"
+```
+
 ### `getQuery(input)`
 
 Parses and decodes the query object of an input URL into an object.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -381,6 +381,27 @@ export function filterQuery(
 }
 
 /**
+ * Removes the entire query section of the URL.
+ *
+ * @example
+ *
+ * ```js
+ * withoutQuery("/foo?bar=1&baz=2"); // "/foo"
+ * ```
+ *
+ * @group utils
+ */
+export function withoutQuery(input: string): string {
+  if (!input.includes("?")) {
+    return input;
+  }
+
+  const parsed = parseURL(input);
+  parsed.search = "";
+  return stringifyParsedURL(parsed);
+}
+
+/**
  * Parses and decodes the query object of an input URL into an object.
  *
  * @example

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { filterQuery, getQuery, withQuery } from "../src";
+import { filterQuery, getQuery, withQuery, withoutQuery } from "../src";
 
 describe("withQuery", () => {
   const tests = [
@@ -83,6 +83,25 @@ describe("filterQuery", () => {
   for (const t of tests) {
     test(t.input.toString() + ' filter "bar"', () => {
       expect(filterQuery(t.input, predicate)).toBe(t.out);
+    });
+  }
+});
+
+describe("withoutQuery", () => {
+  const tests = [
+    { input: "/foo", out: "/foo" },
+    { input: "/foo?bar=1", out: "/foo" },
+    { input: "/foo?bar=1&baz=2", out: "/foo" },
+    {
+      input: "http://example.com/path?q=1#hash",
+      out: "http://example.com/path#hash",
+    },
+    { input: "?standalone=query", out: "" },
+  ];
+
+  for (const t of tests) {
+    test(t.input.toString(), () => {
+      expect(withoutQuery(t.input)).toBe(t.out);
     });
   }
 });


### PR DESCRIPTION
## Summary
- Add `withoutQuery(input)` to strip the entire query section from a URL
- Complements `filterQuery` when all query parameters should be removed
- Includes tests and README documentation

Fixes #297

## Test plan
- [x] `pnpm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new utility function to remove query parameters from URLs while preserving the base path and fragments.

* **Documentation**
  * Updated documentation with usage examples for the new utility function.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/ufo/pull/342?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->