### PR TITLE
fix(parseQuery): parse JSON object and array query values

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -16,7 +16,22 @@ export type QueryValue =
 
 export type QueryObject = Record<string, QueryValue | QueryValue[]>;
 
-export type ParsedQuery = Record<string, string | string[]>;
+export type ParsedQuery = Record<string, QueryValue | QueryValue[]>;
+
+const parseQueryJsonValue = (value: string): QueryValue => {
+  if (
+    (value.startsWith("{") && value.endsWith("}")) ||
+    (value.startsWith("[") && value.endsWith("]"))
+  ) {
+    try {
+      return JSON.parse(value);
+    } catch {
+      // noop
+    }
+  }
+
+  return value;
+};
 
 // const EmptyObject = /* @__PURE__ */ (() => {
 //   const C = function () {};
@@ -37,6 +52,9 @@ export type ParsedQuery = Record<string, string | string[]>;
  *
  * parseQuery("tags=javascript&tags=web&tags=dev");
  * // { tags: ["javascript", "web", "dev"] }
+ *
+ * parseQuery("foo=2&bar=%7B%22k%22:%22v%22%7D");
+ * // { foo: "2", bar: { k: "v" } }
  * ```
  *
  * @note
@@ -62,13 +80,13 @@ export function parseQuery<T extends ParsedQuery = ParsedQuery>(
     if (key === "__proto__" || key === "constructor") {
       continue;
     }
-    const value = decodeQueryValue(s[2] || "");
+    const value = parseQueryJsonValue(decodeQueryValue(s[2] || ""));
     if (object[key] === undefined) {
       object[key] = value;
     } else if (Array.isArray(object[key])) {
-      (object[key] as string[]).push(value);
+      (object[key] as QueryValue[]).push(value);
     } else {
-      object[key] = [object[key] as string, value];
+      object[key] = [object[key] as QueryValue, value];
     }
   }
   return object as T;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,11 @@
 import { parseURL, stringifyParsedURL } from "./parse";
-import { QueryObject, parseQuery, stringifyQuery, ParsedQuery } from "./query";
+import {
+  QueryObject,
+  QueryValue,
+  parseQuery,
+  stringifyQuery,
+  ParsedQuery,
+} from "./query";
 import {
   decode,
   decodePath,
@@ -365,7 +371,7 @@ export function withQuery(input: string, query: QueryObject): string {
  */
 export function filterQuery(
   input: string,
-  predicate: (key: string, value: string | string[]) => boolean,
+  predicate: (key: string, value: QueryValue | QueryValue[]) => boolean,
 ): string {
   if (!input.includes("?")) {
     return input;

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -98,7 +98,7 @@ describe("getQuery", () => {
     "http://foo.com/?param=": { param: "" },
     "http://foo.com/?param=&param=2&param=3": { param: ["", "2", "3"] },
     "http://foo.com/?param=%7B%22a%22:%5B%7B%22obj%22:%5B1,2,3%5D%7D%5D%7D": {
-      param: '{"a":[{"obj":[1,2,3]}]}',
+      param: { a: [{ obj: [1, 2, 3] }] },
     },
     "http://foo.com/?toString=foo": { toString: "foo" },
   };
@@ -108,4 +108,12 @@ describe("getQuery", () => {
       expect(getQuery(t)).toMatchObject(tests[t]);
     });
   }
+
+  test("parses nested json objects created by withQuery", () => {
+    const url = withQuery("https://foo.com/", { foo: 2, bar: { k: "v" } });
+    expect(getQuery(url)).toMatchObject({
+      foo: "2",
+      bar: { k: "v" },
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Parse JSON object/array query values encoded by `stringifyQuery` / `withQuery`
- Enables `getQuery` roundtrip for nested payloads like `{ bar: { k: "v" } }`
- Widen `ParsedQuery` and `filterQuery` predicate types accordingly

Fixes #271

## Test plan
- [x] `pnpm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Query parameters now support JSON objects, arrays, and multiple data types (booleans, numbers, null values) in addition to strings, enabling more complex data structures to be passed through URLs.

* **Tests**
  * Added test coverage for parsing and handling nested JSON structures in query parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/ufo/pull/343?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->