### PR TITLE
feat: add withPathParameters utility

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,6 +5,7 @@ import {
   decodePath,
   encodeHash,
   encodeHost,
+  encodeParam,
   encodePath,
 } from "./encoding";
 
@@ -349,6 +350,51 @@ export function withQuery(input: string, query: QueryObject): string {
   const parsed = parseURL(input);
   const mergedQuery = { ...parseQuery(parsed.search), ...query };
   parsed.search = stringifyQuery(mergedQuery);
+  return stringifyParsedURL(parsed);
+}
+
+const DEFAULT_PATH_PARAM_RE = /\{([^}]+)\}/g;
+
+export interface WithPathParametersOptions {
+  interpolate?: RegExp;
+}
+
+/**
+ * Replace path parameters in the input URL.
+ *
+ * @example
+ *
+ * ```js
+ * withPathParameters("/api/users/{userId}", { userId: "abc" }); // "/api/users/abc"
+ *
+ * withPathParameters("/api/users/{{userId}}", { userId: "abc" }, {
+ *   interpolate: /\{\{([\s\S]+?)\}\}/g,
+ * }); // "/api/users/abc"
+ * ```
+ *
+ * @group utils
+ */
+export function withPathParameters(
+  input: string,
+  params: Record<string, string | number>,
+  options?: WithPathParametersOptions,
+): string {
+  const interpolate = options?.interpolate ?? DEFAULT_PATH_PARAM_RE;
+  const parsed = parseURL(input);
+
+  parsed.pathname = parsed.pathname.replace(
+    interpolate,
+    (match, key: string) => {
+      const paramKey = key.trim();
+
+      if (!(paramKey in params)) {
+        return match;
+      }
+
+      return encodeParam(params[paramKey]!);
+    },
+  );
+
   return stringifyParsedURL(parsed);
 }
 

--- a/test/path-parameters.test.ts
+++ b/test/path-parameters.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "vitest";
+import { withPathParameters } from "../src";
+
+describe("withPathParameters", () => {
+  test("replaces curly-brace path parameters", () => {
+    expect(withPathParameters("/api/users/{userId}", { userId: "abc" })).toBe(
+      "/api/users/abc",
+    );
+  });
+
+  test("supports mustache-style interpolation", () => {
+    expect(
+      withPathParameters(
+        "/api/users/{{userId}}",
+        { userId: "abc" },
+        { interpolate: /\{\{([\s\S]+?)\}\}/g },
+      ),
+    ).toBe("/api/users/abc");
+  });
+
+  test("encodes parameter values", () => {
+    expect(withPathParameters("/api/users/{userId}", { userId: "a/b?c" })).toBe(
+      "/api/users/a%2Fb%3Fc",
+    );
+  });
+
+  test("preserves placeholders when params are missing", () => {
+    expect(withPathParameters("/api/users/{userId}", {})).toBe(
+      "/api/users/{userId}",
+    );
+  });
+
+  test("works with full URLs", () => {
+    expect(
+      withPathParameters("https://example.com/api/{id}/view", { id: "42" }),
+    ).toBe("https://example.com/api/42/view");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `withPathParameters()` to replace `{param}` placeholders in URL paths
- Supports custom interpolation patterns (e.g. mustache `{{param}}`) via `{ interpolate: RegExp }`
- Encodes substituted values with `encodeParam` and leaves unknown placeholders unchanged

## Test plan

- [x] `pnpm test` (496 tests)
- [x] Covers default braces, mustache mode, encoding, missing params, and full URLs

Closes #243

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced path parameter substitution utility for dynamically inserting values into URL paths
  * Automatically URL-encodes substituted parameter values
  * Supports custom regex patterns for flexible parameter placeholder matching
  * Properly handles complete URLs and preserves unmatched placeholders

* **Tests**
  * Added test suite validating parameter substitution across various scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/ufo/pull/344?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->