### PR TITLE
fix(encoding): encode pipe as %7C in query values

### DIFF
--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -9,6 +9,7 @@ const SLASH_RE = /\//g; // %2F
 const EQUAL_RE = /=/g; // %3D
 const IM_RE = /\?/g; // %3F
 const PLUS_RE = /\+/g; // %2B
+const PIPE_RE = /\|/g; // %7C
 
 const ENC_CARET_RE = /%5e/gi; // ^
 const ENC_BACKTICK_RE = /%60/gi; // `
@@ -67,6 +68,7 @@ export function encodeQueryValue(input: QueryValue): string {
       .replace(ENC_BACKTICK_RE, "`")
       .replace(ENC_CARET_RE, "^")
       .replace(SLASH_RE, "%2F")
+      .replace(PIPE_RE, "%7C")
   );
 }
 

--- a/test/encoding.test.ts
+++ b/test/encoding.test.ts
@@ -95,8 +95,9 @@ describe("encodeQueryValue", () => {
     },
     {
       input: String.raw`!@#$%^&*()_+{}[]|\:;<>,./?`,
-      out: "!@%23$%25^%26*()_%2B%7B%7D%5B%5D|%5C:;%3C%3E,.%2F?",
+      out: "!@%23$%25^%26*()_%2B%7B%7D%5B%5D%7C%5C:;%3C%3E,.%2F?",
     },
+    { input: "a|b", out: "a%7Cb" },
   ];
 
   for (const t of tests) {


### PR DESCRIPTION
## Summary

- Encode `|` as `%7C` in `encodeQueryValue` after the existing `encode()` pass
- Matches how other reserved query characters (`#`, `&`, `` ` ``, `^`, `/`) are re-encoded

Fixes #233

## Test plan

- [x] Updated special-character test expectation for `encodeQueryValue`
- [x] Added `a|b` → `a%7Cb` test case
- [x] `pnpm test` (492 tests pass)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pipe characters (|) in query values are now properly percent-encoded as %7C during URL encoding.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/ufo/pull/346?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->