### PR TITLE
fix(encoding): encode semicolon in query values

### DIFF
--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -9,6 +9,7 @@ const SLASH_RE = /\//g; // %2F
 const EQUAL_RE = /=/g; // %3D
 const IM_RE = /\?/g; // %3F
 const PLUS_RE = /\+/g; // %2B
+const SEMICOLON_RE = /;/g; // %3B
 
 const ENC_CARET_RE = /%5e/gi; // ^
 const ENC_BACKTICK_RE = /%60/gi; // `
@@ -67,6 +68,7 @@ export function encodeQueryValue(input: QueryValue): string {
       .replace(ENC_BACKTICK_RE, "`")
       .replace(ENC_CARET_RE, "^")
       .replace(SLASH_RE, "%2F")
+      .replace(SEMICOLON_RE, "%3B")
   );
 }
 

--- a/test/encoding.test.ts
+++ b/test/encoding.test.ts
@@ -95,8 +95,9 @@ describe("encodeQueryValue", () => {
     },
     {
       input: String.raw`!@#$%^&*()_+{}[]|\:;<>,./?`,
-      out: "!@%23$%25^%26*()_%2B%7B%7D%5B%5D|%5C:;%3C%3E,.%2F?",
+      out: "!@%23$%25^%26*()_%2B%7B%7D%5B%5D|%5C:%3B%3C%3E,.%2F?",
     },
+    { input: "sec;ret", out: "sec%3Bret" },
   ];
 
   for (const t of tests) {

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -63,6 +63,11 @@ describe("withQuery", () => {
       query: { a: "X", "b[]": [], c: "Y" },
       out: "/?a=X&c=Y",
     },
+    {
+      input: "/foo?page=a",
+      query: { token: "sec;ret" },
+      out: "/foo?page=a&token=sec%3Bret",
+    },
   ];
 
   for (const t of tests) {


### PR DESCRIPTION
## Summary

- Encode `;` as `%3B` in `encodeQueryValue` so `withQuery` does not leave semicolons unescaped in query values
- `encodeURI` intentionally leaves `;` unencoded; query values need explicit encoding

Closes #240

## Test plan

- [x] `pnpm test` (493 tests + typecheck)
- [x] Added cases for `sec;ret` and `withQuery('/foo?page=a', { token: 'sec;ret' })`