### PR TITLE
fix(encoding): encode backtick as %60 in encodeQueryValue

### DIFF
--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -11,7 +11,6 @@ const IM_RE = /\?/g; // %3F
 const PLUS_RE = /\+/g; // %2B
 
 const ENC_CARET_RE = /%5e/gi; // ^
-const ENC_BACKTICK_RE = /%60/gi; // `
 const ENC_CURLY_OPEN_RE = /%7b/gi; // {
 const ENC_PIPE_RE = /%7c/gi; // |
 const ENC_CURLY_CLOSE_RE = /%7d/gi; // }
@@ -64,7 +63,6 @@ export function encodeQueryValue(input: QueryValue): string {
       .replace(ENC_SPACE_RE, "+")
       .replace(HASH_RE, "%23")
       .replace(AMPERSAND_RE, "%26")
-      .replace(ENC_BACKTICK_RE, "`")
       .replace(ENC_CARET_RE, "^")
       .replace(SLASH_RE, "%2F")
   );

--- a/test/encoding.test.ts
+++ b/test/encoding.test.ts
@@ -97,6 +97,7 @@ describe("encodeQueryValue", () => {
       input: String.raw`!@#$%^&*()_+{}[]|\:;<>,./?`,
       out: "!@%23$%25^%26*()_%2B%7B%7D%5B%5D|%5C:;%3C%3E,.%2F?",
     },
+    { input: "a`b", out: "a%60b" },
   ];
 
   for (const t of tests) {


### PR DESCRIPTION
Closes #302

## Bug

`encodeQueryValue("a\`b")` returns `"a\`b"` instead of `"a%60b"`.

The backtick (`` ` ``) is an **unsafe** character per [RFC 1738 §2.2](https://datatracker.ietf.org/doc/html/rfc1738#section-2.2) and must be percent-encoded in URLs.

`encodeURI` (called inside `encode()`) already encodes the backtick correctly as `%60`. However, `encodeQueryValue` then immediately called `.replace(ENC_BACKTICK_RE, "\`")` — which decoded `%60` back to a literal backtick, undoing the correct encoding.

## Fix

Remove the `.replace(ENC_BACKTICK_RE, "\`")` line from `encodeQueryValue` so the `%60` produced by `encodeURI` is preserved. Also remove the now-unused `ENC_BACKTICK_RE` constant.

`encodeQueryKey` delegates to `encodeQueryValue`, so it inherits the fix automatically.

## Test

Added to `test/encoding.test.ts`:

```ts
{ input: "a`b", out: "a%60b" }
```

Verified:
- **Fails without the fix**: `expected 'a\`b' to strictly equal 'a%60b'`
- **Passes with the fix**: all 59 encoding tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL query parameter encoding to correctly handle special characters, including backticks and carets.

* **Tests**
  * Added test coverage for special character encoding in query parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->