### PR TITLE
fix(withBase): treat protocol-relative URLs as absolute

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -288,7 +288,7 @@ export function cleanDoubleSlashes(input = ""): string {
  * @group utils
  */
 export function withBase(input: string, base: string) {
-  if (isEmptyURL(base) || hasProtocol(input)) {
+  if (isEmptyURL(base) || hasProtocol(input, { acceptRelative: true })) {
     return input;
   }
   const _base = withoutTrailingSlash(base);

--- a/test/base.test.ts
+++ b/test/base.test.ts
@@ -13,6 +13,18 @@ describe("withBase", () => {
     { base: "/base/", input: "/base/a", out: "/base/a" },
     { base: "/base/", input: "https://test.com", out: "https://test.com" },
     { base: "/", input: "https://test.com", out: "https://test.com" },
+    // Protocol-relative URLs are absolute and should not get a base prepended
+    {
+      base: "/app",
+      input: "//cdn.example.com/asset.js",
+      out: "//cdn.example.com/asset.js",
+    },
+    { base: "/app/", input: "//cdn.example.com", out: "//cdn.example.com" },
+    {
+      base: "/",
+      input: "//cdn.example.com/path",
+      out: "//cdn.example.com/path",
+    },
     {
       base: "/admin/",
       input: "/admin-dashboard",


### PR DESCRIPTION
`withBase` skips prepending the base when the input already has a protocol, but it was calling `hasProtocol(input)` with default options. The default does not match protocol-relative URLs like `//cdn.example.com`, so `withBase` was falling through to `joinURL` and producing broken output:

```js
withBase("//cdn.example.com/asset.js", "/app")
// before: "/app//cdn.example.com/asset.js"
// after:  "//cdn.example.com/asset.js"
```

A protocol-relative URL carries an implicit host and is effectively absolute. It should be returned unchanged, just like `https://` URLs are. The fix is to pass `{ acceptRelative: true }` to `hasProtocol`, which already exists for exactly this purpose.

Three tests cover the new behavior: a path-only base, a trailing-slash base, and the root `/` base. All 494 tests pass, lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed URL handling to properly recognize protocol-relative URLs (starting with //) and prevent them from being incorrectly modified by base path settings, improving path resolution reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->