### PR TITLE
fix: don't add // authority when stringifying opaque-path protocols

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -3,6 +3,9 @@ import { hasProtocol } from "./utils";
 
 const protocolRelative = Symbol.for("ufo:protocolRelative");
 
+// Protocols whose value is an opaque path (no `//` authority component).
+const OPAQUE_PROTOCOL_RE = /^(?:blob|data|javascript|vbscript):$/i;
+
 export interface ParsedURL {
   protocol?: string;
   host?: string;
@@ -187,10 +190,14 @@ export function stringifyParsedURL(parsed: Partial<ParsedURL>): string {
   const hash = parsed.hash || "";
   const auth = parsed.auth ? parsed.auth + "@" : "";
   const host = parsed.host || "";
-  const proto =
-    parsed.protocol || parsed[protocolRelative]
-      ? (parsed.protocol || "") + "//"
-      : "";
+  let proto = "";
+  if (parsed.protocol && OPAQUE_PROTOCOL_RE.test(parsed.protocol)) {
+    // Opaque-path protocols (e.g. `data:`, `blob:`) are not followed by a `//`
+    // authority, so emitting one corrupts the URL on round-trip.
+    proto = parsed.protocol;
+  } else if (parsed.protocol || parsed[protocolRelative]) {
+    proto = (parsed.protocol || "") + "//";
+  }
   return proto + auth + host + pathname + search + hash;
 }
 

--- a/test/normalize.test.ts
+++ b/test/normalize.test.ts
@@ -42,6 +42,8 @@ describe("normalizeURL", () => {
       "http://localhost/abc/deg%2F%3F%26?email=some+v1@email.com&foo=bar",
     "http://example.com/foo\\bar": "http://example.com/foo/bar",
     "\0http://google.com": "http://google.com",
+    "data:text/plain;base64,aGVsbG8=": "data:text/plain;base64,aGVsbG8=",
+    "blob:https://example.com/uuid": "blob:https://example.com/uuid",
   };
 
   const validURLS = [

--- a/test/utilities.test.ts
+++ b/test/utilities.test.ts
@@ -4,6 +4,7 @@ import {
   isEqual,
   isRelative,
   parsePath,
+  parseURL,
   stringifyParsedURL,
   withHttp,
   withHttps,
@@ -122,6 +123,19 @@ describe("stringifyParsedURL", () => {
       input: { protocol: "https:", host: "google.com" },
       out: "https://google.com",
     },
+    // Opaque-path protocols must not gain a `//` authority (round-trip safe).
+    {
+      input: { protocol: "data:", pathname: "text/plain;base64,aGVsbG8=" },
+      out: "data:text/plain;base64,aGVsbG8=",
+    },
+    {
+      input: { protocol: "blob:", pathname: "https://example.com/uuid" },
+      out: "blob:https://example.com/uuid",
+    },
+    {
+      input: { protocol: "javascript:", pathname: "alert(1)" },
+      out: "javascript:alert(1)",
+    },
   ];
 
   for (const t of tests) {
@@ -133,6 +147,17 @@ describe("stringifyParsedURL", () => {
       ).toBe(t.out);
     });
   }
+
+  test("round-trips opaque-path protocols (data:, blob:, javascript:)", () => {
+    for (const input of [
+      "data:text/plain;base64,aGVsbG8=",
+      "data:image/png;base64,aaa//bbbbbb/ccc",
+      "blob:https://example.com/550e8400",
+      "javascript:alert('hello')",
+    ]) {
+      expect(stringifyParsedURL(parseURL(input))).toBe(input);
+    }
+  });
 });
 
 describe("withHttp", () => {


### PR DESCRIPTION
I noticed `stringifyParsedURL(parseURL(x))` corrupts `data:` URLs (and other opaque-path schemes), and the damage compounds on every round-trip:

```js
import { parseURL, stringifyParsedURL, normalizeURL } from "ufo";

stringifyParsedURL(parseURL("data:text/plain"));
// "data://text/plain"   ← spurious //

normalizeURL("data:text/plain");                 // "data://text/plain"
normalizeURL(normalizeURL("data:text/plain"));   // "data:////text/plain"
// each pass adds two more slashes
```

Same for `blob:`, `javascript:` and `vbscript:`.

`parseURL` correctly keeps the opaque path of these schemes (that was fixed in #158), but `stringifyParsedURL` always appended `//` after any protocol — opaque-path schemes have no `//` authority, so the extra slashes break the URL and the parse↔stringify round-trip.

The fix only emits the `//` authority for non-opaque protocols (or protocol-relative URLs). `file://`, `http://`, `//host` and protocol-relative URLs are unaffected.

Found by fuzzing the parse→stringify round-trip / `normalizeURL` idempotency. Added stringify round-trip cases plus two `normalizeURL` cases; full suite, lint and typecheck pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed URL parsing logic to correctly handle opaque protocols (`data:`, `blob:`, `javascript:`, `vbscript:`). These special protocols now preserve their format during round-trip serialization without incorrectly appending authority prefixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->