### PR TITLE
fix(encoding): encode ^, ` and ? in encodeQueryValue

### DIFF
--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -64,8 +64,7 @@ export function encodeQueryValue(input: QueryValue): string {
       .replace(ENC_SPACE_RE, "+")
       .replace(HASH_RE, "%23")
       .replace(AMPERSAND_RE, "%26")
-      .replace(ENC_BACKTICK_RE, "`")
-      .replace(ENC_CARET_RE, "^")
+      .replace(IM_RE, "%3F")
       .replace(SLASH_RE, "%2F")
   );
 }


### PR DESCRIPTION
## Summary

`encodeQueryValue` had three bugs where unsafe characters were left unencoded in query string values:

1. **Backtick (\`)** (#302): `.replace(ENC_BACKTICK_RE, "\`")` was actively _decoding_ `%60` back to a raw backtick after `encodeURI` had correctly encoded it. This line has been removed.

2. **Caret (^)** (#304): `.replace(ENC_CARET_RE, "^")` was actively _decoding_ `%5E` back to a raw caret after `encodeURI` had correctly encoded it. This line has been removed.

3. **Question mark (?)** (#301): `encodeURI()` does not encode `?` (it is a reserved URI character), and nothing in `encodeQueryValue` was adding it. Added `.replace(IM_RE, "%3F")` to encode it — consistent with how `encodePath` already handles `?`.

Note: `ENC_CARET_RE` and `ENC_BACKTICK_RE` are still used in `encodeHash()` where those characters are intentionally allowed, so the regex constants themselves are preserved.

## Issues fixed

- Fixes #301 (`?` not encoded in query values)
- Fixes #302 (backtick not encoded in query values)
- Fixes #304 (caret `^` not encoded in query values)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL query parameter encoding to properly handle special characters in search queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->