### PR TITLE
fix(parseQuery): keep the value of an empty-key parameter

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -54,7 +54,10 @@ export function parseQuery<T extends ParsedQuery = ParsedQuery>(
     parametersString = parametersString.slice(1);
   }
   for (const parameter of parametersString.split("&")) {
-    const s = parameter.match(/([^=]+)=?(.*)/) || [];
+    if (!parameter) {
+      continue;
+    }
+    const s = parameter.match(/([^=]*)=?(.*)/) || [];
     if (s.length < 2) {
       continue;
     }

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -109,3 +109,18 @@ describe("getQuery", () => {
     });
   }
 });
+
+describe("parseQuery empty key", () => {
+  // Matches URLSearchParams: "=b" -> [["","b"]]
+  const tests = {
+    "http://foo.com/?=b": { "": "b" },
+    "http://foo.com/?a=1&=b": { a: "1", "": "b" },
+    "http://foo.com/?==": { "": "=" },
+    "http://foo.com/?=b&=c": { "": ["b", "c"] },
+  };
+  for (const t in tests) {
+    test(t, () => {
+      expect(getQuery(t)).toMatchObject(tests[t]);
+    });
+  }
+});


### PR DESCRIPTION
## Problem

`parseQuery` matches each parameter with `/([^=]+)=?(.*)/`. The key sub-pattern `[^=]+` requires at least one non-`=` character, so for an empty-key parameter the match anchors past the `=`:

- `=b` parses as `{ b: "" }`: the real value `"b"` is silently lost and a spurious key `"b"` is invented.
- `==` and a bare `=` are dropped entirely.

This corrupts `parseQuery`, `getQuery`, `filterQuery`, and `normalizeURL` for any URL carrying an empty-key parameter.

WHATWG `URLSearchParams` keeps the empty key:

```js
[...new URLSearchParams("=b")]      // [["", "b"]]
[...new URLSearchParams("a=1&=b")]  // [["a", "1"], ["", "b"]]
[...new URLSearchParams("==")]      // [["", "="]]
[...new URLSearchParams("")]        // []
```

## Fix

Change the key pattern `[^=]+` to `[^=]*` so an empty key matches, and add an explicit skip of fully-empty parts (`if (!parameter) continue;`) to preserve the current behavior of dropping `""` and `&&` (with the star pattern the match no longer returns a length-0 array, so the skip has to be explicit).

After the fix, `parseQuery` matches `URLSearchParams` across the matrix:

| input | before | after / `URLSearchParams` |
|---|---|---|
| `""` | `{}` | `{}` |
| `=b` | `{ b: "" }` | `{ "": "b" }` |
| `a=1&=b` | `{ a: "1", b: "" }` | `{ a: "1", "": "b" }` |
| `==` | `{}` | `{ "": "=" }` |
| `&` | `{}` | `{}` |
| `a` | `{ a: "" }` | `{ a: "" }` |
| `a=` | `{ a: "" }` | `{ a: "" }` |
| `&&` | `{}` | `{}` |
| `=b&=c` | `{ b: "", c: "" }` | `{ "": ["b", "c"] }` |

## Tests

Added four empty-key cases to `test/query.test.ts`. They fail on the current code (red) and pass with the fix (green); the full suite stays green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced query parameter parsing to correctly handle edge cases where query strings contain empty keys.

* **Tests**
  * Expanded test suite to verify proper handling of query parameters with empty keys in various URL formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->