### PR TITLE
fix(query): add early exit guard for empty parameter fragments in parseQuery

### DIFF
--- a/src/punycode.ts
+++ b/src/punycode.ts
@@ -31,7 +31,7 @@ export function toASCII(o) {
     const s = (function (n, t) {
       const o = [];
       let e = n.length;
-      for (; e--; ) {
+      for (; e--;) {
         o[e] = t(n[e]);
       }
       return o;
@@ -46,7 +46,7 @@ export function toASCII(o) {
               const t = [];
               let o = 0;
               const e = n.length;
-              for (; o < e; ) {
+              for (; o < e;) {
                 const r = n.charCodeAt(o++);
                 if (r >= 55296 && r <= 56319 && o < e) {
                   const e = n.charCodeAt(o++);
@@ -67,7 +67,7 @@ export function toASCII(o) {
             }
             const h = t.length;
             let p = h;
-            for (h && t.push("-"); p < o; ) {
+            for (h && t.push("-"); p < o;) {
               let o = 2147483647;
               for (const t of n) {
                 t >= f && t < o && (o = t);

--- a/src/query.ts
+++ b/src/query.ts
@@ -54,6 +54,9 @@ export function parseQuery<T extends ParsedQuery = ParsedQuery>(
     parametersString = parametersString.slice(1);
   }
   for (const parameter of parametersString.split("&")) {
+    if (!parameter) {
+      continue;
+    }
     const s = parameter.match(/([^=]+)=?(.*)/) || [];
     if (s.length < 2) {
       continue;


### PR DESCRIPTION
### Description
This PR introduces an explicit validation guard at the top of the query parameter parsing loop inside `parseQuery` to cleanly drop empty token fragments (e.g., from consecutive delimiters `&&` or trailing ampersands `&`) before they propagate downstream.

### Technical Context
When parsing incoming query parameters, `parametersString.split("&")` evaluates strings into array fragments. If a URL string contains contiguous or dangling operators, the split function populates the collection slice with raw empty strings (`""`). 

While subsequent internal regex evaluations handle these elements safely from populating dirty key outputs, allowing the execution pipeline to continue running regular expression compilation matches on empty tokens adds unnecessary structural processing.

### Resolution Strategy
* **Short-Circuit Token Guard:** Injected an immediate inline check (`if (!parameter) { continue; }`) right at the initiation boundary of the `for...of` loop inside `src/query.ts`.
* **Zero Overhead Validation:** Definitively intercepts empty slice structures out of the gate, saving execution overhead and reinforcing key-assignment stability under malformed input profiles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query-string parsing to ignore empty segments from consecutive or trailing `&`, preventing malformed inputs from being treated as parameters while preserving existing decoding behavior.

* **Chores / Style**
  * Adjusted formatting in the Punycode `toASCII` implementation (whitespace cleanup in a minified loop header) with no functional impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->