### PR TITLE
docs: fix normalizeURL example output (query space is + not %20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ Normalizes the input URL:
 
 ```js
 normalizeURL("test?query=123 123#hash, test");
-// Returns "test?query=123%20123#hash,%20test"
+// Returns "test?query=123+123#hash,%20test"
 
 normalizeURL("http://localhost:3000");
 // Returns "http://localhost:3000"

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -586,7 +586,7 @@ export function withProtocol(input: string, protocol: string): string {
  *
  * ```js
  * normalizeURL("test?query=123 123#hash, test");
- * // Returns "test?query=123%20123#hash,%20test"
+ * // Returns "test?query=123+123#hash,%20test"
  *
  * normalizeURL("http://localhost:3000");
  * // Returns "http://localhost:3000"


### PR DESCRIPTION
The `normalizeURL` JSDoc example shows the query-string space encoded as `%20`, but the function encodes query-string spaces as `+` (through `encodeQueryValue` in `src/encoding.ts`). The hash part is correctly `%20`.

Running the example:

```js
normalizeURL("test?query=123 123#hash, test")
// actual:   "test?query=123+123#hash,%20test"
// example:  "test?query=123%20123#hash,%20test"
```

Updated the example to the real output. The README block is generated from this JSDoc, so I reran `pnpm automd` to keep it in sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `normalizeURL` example to show the current expected encoding format for spaces in query/hash output.
  * Aligned the README and inline usage example so they now reflect `+` encoding instead of `%20` for that sample case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->