### PR TITLE
fix(withFragment): clear fragment when hash is an empty string

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -734,7 +734,7 @@ export function isEqual(a: string, b: string, options: CompareURLOptions = {}) {
  * @group utils
  */
 export function withFragment(input: string, hash: string): string {
-  if (!hash || hash === "#") {
+  if (hash === undefined || hash === null || hash === "#") {
     return input;
   }
   const parsed = parseURL(input);

--- a/test/utilities.test.ts
+++ b/test/utilities.test.ts
@@ -291,6 +291,11 @@ describe("withFragment", () => {
     { input: "https://example.com", fragment: "", out: "https://example.com" },
     {
       input: "https://example.com#bar",
+      fragment: "",
+      out: "https://example.com",
+    },
+    {
+      input: "https://example.com#bar",
       fragment: "0",
       out: "https://example.com#0",
     },


### PR DESCRIPTION
The JSDoc example on `withFragment` documents that passing an empty string clears the fragment:

```js
withFragment("/foo#bar", ""); // "/foo"
```

But the guard `if (!hash || hash === "#")` returns the input untouched whenever `hash` is an empty string, so:

```js
withFragment("https://example.com#bar", ""); // "https://example.com#bar" (expected "https://example.com")
```

The body already has `parsed.hash = hash === "" ? "" : "#" + encodeHash(hash)`, so the empty-string branch was written to clear the fragment but is unreachable because of the early return.

This narrows the guard to short-circuit only on `undefined` / `null` / `"#"`, letting an empty string fall through to the existing clear branch. The `undefined` / `null` and `"#"` cases keep their previous no-op behavior.

Added a test for clearing an existing fragment with `""`. The existing `withFragment("https://example.com", "")` case (no fragment present) stays green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated URL fragment handling so an empty fragment now removes any existing hash instead of leaving the original URL unchanged.
  * Added coverage to verify that clearing a fragment produces the expected cleaned URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->