### PR TITLE
fix(withBase, withoutBase): treat "#" as a base boundary

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -295,7 +295,7 @@ export function withBase(input: string, base: string) {
   if (input.startsWith(_base)) {
     const nextChar = input[_base.length];
     // Ensure '/admin-dashboard' is not considered as having base '/admin/'
-    if (!nextChar || nextChar === "/" || nextChar === "?") {
+    if (!nextChar || nextChar === "/" || nextChar === "?" || nextChar === "#") {
       return input;
     }
   }
@@ -325,7 +325,7 @@ export function withoutBase(input: string, base: string) {
   }
   // Ensure '/admin-dashboard' is not considered as having base '/admin/'
   const nextChar = input[_base.length];
-  if (nextChar && nextChar !== "/" && nextChar !== "?") {
+  if (nextChar && nextChar !== "/" && nextChar !== "?" && nextChar !== "#") {
     return input;
   }
   // Collapse leading slashes to prevent protocol-relative URL injection

--- a/test/base.test.ts
+++ b/test/base.test.ts
@@ -11,6 +11,8 @@ describe("withBase", () => {
     { base: "/base", input: "/base/", out: "/base/" },
     { base: "/base", input: "/base/a", out: "/base/a" },
     { base: "/base/", input: "/base/a", out: "/base/a" },
+    { base: "/base", input: "/base#section", out: "/base#section" },
+    { base: "/base/", input: "/base#/route", out: "/base#/route" },
     { base: "/base/", input: "https://test.com", out: "https://test.com" },
     { base: "/", input: "https://test.com", out: "https://test.com" },
     {
@@ -52,6 +54,8 @@ describe("withoutBase", () => {
     { base: "/", input: "/test/", out: "/test/" },
     { base: "/", input: "/?test", out: "/?test" },
     { base: "/api", input: "/api?test", out: "/?test" },
+    { base: "/api", input: "/api#test", out: "/#test" },
+    { base: "/api", input: "/api#/dashboard", out: "/#/dashboard" },
     { base: "/base/", input: "https://test.com", out: "https://test.com" },
     { base: "/", input: "https://test.com", out: "https://test.com" },
     { base: "/admin/", input: "/admin-dashboard", out: "/admin-dashboard" },


### PR DESCRIPTION
Follow-up to #313. The boundary guard added there recognizes `/` and `?` after the base but not `#`, so a fragment directly after the base defeats both functions:

```ts
withoutBase("/api#section", "/api"); // "/api#section" (expected "/#section")
withBase("/api#section", "/api"); // "/api/api#section" (expected "/api#section")
```

`#` is a boundary in the same sense `?` is: `/api#section` is the base path plus a fragment, not a longer path that happens to share a prefix. The practical shape is SPA hash routing (`/app#/dashboard`).

The fix adds `#` to both guards, mirroring the existing `?` handling. Tests added next to the existing `/api?test` row: four new rows covering strip (`withoutBase`) and idempotent no-op (`withBase`), red before the fix, full suite green after (493/493).

Found while testing an automated review tool I've been building; verified by hand against `main` before opening this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved base URL handling when paths contain fragments.
  * Preserved fragment portions while adding or removing a base path from URLs.

* **Tests**
  * Added coverage for URL fragments in both base-prefix operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->