### PR TITLE
fix(query): treat keys ending with [] as arrays in parseQuery

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -37,6 +37,9 @@ export type ParsedQuery = Record<string, string | string[]>;
  *
  * parseQuery("tags=javascript&tags=web&tags=dev");
  * // { tags: ["javascript", "web", "dev"] }
+ *
+ * parseQuery("filter[size][]=large");
+ * // { "filter[size]": ["large"] }
  * ```
  *
  * @note
@@ -59,16 +62,19 @@ export function parseQuery<T extends ParsedQuery = ParsedQuery>(
       continue;
     }
     const key = decodeQueryKey(s[1]);
-    if (key === "__proto__" || key === "constructor") {
+    // Keys ending with "[]" are treated as arrays, even for a single value
+    const isArrayKey = key.endsWith("[]");
+    const storageKey = isArrayKey ? key.slice(0, -2) : key;
+    if (storageKey === "__proto__" || storageKey === "constructor") {
       continue;
     }
     const value = decodeQueryValue(s[2] || "");
-    if (object[key] === undefined) {
-      object[key] = value;
-    } else if (Array.isArray(object[key])) {
-      (object[key] as string[]).push(value);
+    if (object[storageKey] === undefined) {
+      object[storageKey] = isArrayKey ? [value] : value;
+    } else if (Array.isArray(object[storageKey])) {
+      (object[storageKey] as string[]).push(value);
     } else {
-      object[key] = [object[key] as string, value];
+      object[storageKey] = [object[storageKey] as string, value];
     }
   }
   return object as T;

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -101,6 +101,12 @@ describe("getQuery", () => {
       param: '{"a":[{"obj":[1,2,3]}]}',
     },
     "http://foo.com/?toString=foo": { toString: "foo" },
+    "http://foo.com/?filter[size][]=large": { "filter[size]": ["large"] },
+    "http://foo.com/?filter[size]=large": { "filter[size]": "large" },
+    "http://foo.com/?filter[size][]=large&filter[size][]=medium": {
+      "filter[size]": ["large", "medium"],
+    },
+    "http://foo.com/?foo[]=bar": { foo: ["bar"] },
   };
 
   for (const t in tests) {
@@ -108,4 +114,18 @@ describe("getQuery", () => {
       expect(getQuery(t)).toMatchObject(tests[t]);
     });
   }
+
+  test("ignores __proto__ and constructor keys even with array suffix", () => {
+    const result = getQuery(
+      "http://foo.com/?__proto__[]=bad&constructor[]=bad&safe=ok",
+    ) as Record<string, unknown>;
+    expect(result.safe).toBe("ok");
+    expect(Object.prototype.hasOwnProperty.call(result, "__proto__")).toBe(
+      false,
+    );
+    expect(Object.prototype.hasOwnProperty.call(result, "constructor")).toBe(
+      false,
+    );
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

- `parseQuery` now recognizes PHP-style array notation: a key ending with `[]` (e.g. `filter[size][]`) is stored as an array even when there is only a single occurrence.
- Keys without the `[]` suffix keep the existing scalar/array-on-repeat behavior.
- The array-suffix key is stripped down to its storage key **before** the existing `__proto__`/`constructor` prototype-pollution guard runs, so `constructor[]=x` or `__proto__[]=x` can no longer slip past the check the way they would with a naive implementation.

## Example

```js
parseQuery("filter[size][]=large");
// { "filter[size]": ["large"] }

parseQuery("filter[size]=large");
// { "filter[size]": "large" }

parseQuery("filter[size][]=large&filter[size][]=medium");
// { "filter[size]": ["large", "medium"] }
```

Fixes #296

## Test plan

- [x] `pnpm test` (lint + vitest + typecheck) passes: 496/496 tests
- [x] Added `getQuery` regression cases for single/multiple `[]` keys, plain bracket keys, and repeated values
- [x] Added a dedicated test asserting `__proto__[]`/`constructor[]` are still ignored and cannot pollute the prototype

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query parsing for bracket-notation array parameters, including single and repeated values.
  * Prevented unsafe query keys from affecting parsed results.

* **Tests**
  * Expanded coverage for array-style query parameters and protected-key handling.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->