### PR TITLE
feat: support withoutQuery (strip the whole query section)

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -381,6 +381,29 @@ export function filterQuery(
 }
 
 /**
+ * Removes the entire query section from a URL string, preserving the rest of the
+ * URL (including any hash). Unlike {@link filterQuery}, no predicate is
+ * applied — the whole `?...` section is stripped. See issue #297.
+ *
+ * @example
+ *
+ * ```js
+ * withoutQuery("/foo?bar=1&baz=2#hash"); // "/foo#hash"
+ * withoutQuery("/foo");                  // "/foo"
+ * ```
+ *
+ * @group utils
+ */
+export function withoutQuery(input: string): string {
+  if (!input.includes("?")) {
+    return input;
+  }
+  const parsed = parseURL(input);
+  parsed.search = "";
+  return stringifyParsedURL(parsed);
+}
+
+/**
  * Parses and decodes the query object of an input URL into an object.
  *
  * @example


### PR DESCRIPTION
Closes #297.

Add withoutQuery(input) that removes the `?...` query section, preserving the rest of the URL including any hash. Returns the input unchanged when there is no query. Auto exported via export * from "./utils".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for removing query parameters from URLs while preserving the original path and hash fragment.
  - URLs without query parameters remain unchanged.
  - Included usage documentation and examples for this URL-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->