### PR TITLE
fix: don't add "//" when stringifying opaque-scheme URLs

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -188,9 +188,14 @@ export function stringifyParsedURL(parsed: Partial<ParsedURL>): string {
   const auth = parsed.auth ? parsed.auth + "@" : "";
   const host = parsed.host || "";
   const proto =
-    parsed.protocol || parsed[protocolRelative]
-      ? (parsed.protocol || "") + "//"
-      : "";
+    // Opaque schemes (the ones parseURL special-cases) carry their body in
+    // pathname and have no authority, so they must not gain a "//" — otherwise
+    // "data:…" round-trips to the invalid "data://…".
+    parsed.protocol && /^(?:blob|data|javascript|vbscript):$/i.test(parsed.protocol)
+      ? parsed.protocol
+      : parsed.protocol || parsed[protocolRelative]
+        ? (parsed.protocol || "") + "//"
+        : "";
   return proto + auth + host + pathname + search + hash;
 }
 

--- a/test/utilities.test.ts
+++ b/test/utilities.test.ts
@@ -122,6 +122,16 @@ describe("stringifyParsedURL", () => {
       input: { protocol: "https:", host: "google.com" },
       out: "https://google.com",
     },
+    // Opaque schemes carry their body in pathname and have no authority, so
+    // they must not gain a "//" separator (e.g. "data:…" not "data://…").
+    {
+      input: { protocol: "data:", pathname: "text/plain,hello" },
+      out: "data:text/plain,hello",
+    },
+    {
+      input: { protocol: "blob:", pathname: "https://example.com/id" },
+      out: "blob:https://example.com/id",
+    },
   ];
 
   for (const t of tests) {


### PR DESCRIPTION
parseURL special-cases opaque schemes (`data:`, `blob:`, `javascript:`, `vbscript:`), returning the body in `pathname` with an empty `host` and a correct `href`. But `stringifyParsedURL` appended `//` whenever a protocol was present, so it re-emitted them with an authority separator:

```js
stringifyParsedURL(parseURL("data:text/plain,hello"))
// -> "data://text/plain,hello"   (invalid — should be "data:text/plain,hello")
```

This breaks the documented `parse` -> `stringify` round-trip and propagates through `normalizeURL`, `withQuery`, etc.

The fix skips the `//` for exactly the schemes `parseURL` special-cases. Authority-based schemes (`http://`, protocol-relative `//host`, `file:///`) are unchanged.

Added two round-trip cases to the existing `stringifyParsedURL` test table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected URL serialization for opaque protocols such as `data:`, `blob:`, `javascript:`, and `vbscript:`.
  * Preserved protocol-specific pathname content without adding an incorrect `//` separator.

* **Tests**
  * Added coverage for `data:` and `blob:` URL serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->