### PR TITLE
fix: do not treat host:port as protocol in withProtocol and hasProtocol

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,7 +10,7 @@ import {
 
 const PROTOCOL_STRICT_REGEX = /^[\s\w\0+.-]{2,}:([/\\]{1,2})/;
 const HOST_PORT_REGEX =
-  /^[\s\0]*(?!tel:|fax:|sms:|skype:|callto:)[\w+.-]{2,}:\d+(?:[/?#\\]|$)/i;
+  /^[\s\0]*(?!tel:|fax:|sms:|skype:|callto:|mailto:|data:|javascript:|vbscript:|blob:|urn:|geo:|magnet:)[\w.-]{2,}:\d+(?:[/?#\\]|$)/i;
 const PROTOCOL_REGEX = /^[\s\w\0+.-]{2,}:([/\\]{2})?/;
 const PROTOCOL_RELATIVE_REGEX = /^([/\\]\s*){2,}[^/\\]/;
 const PROTOCOL_SCRIPT_RE = /^[\s\0]*(blob|data|javascript|vbscript):$/i;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,6 +9,8 @@ import {
 } from "./encoding";
 
 const PROTOCOL_STRICT_REGEX = /^[\s\w\0+.-]{2,}:([/\\]{1,2})/;
+const HOST_PORT_REGEX =
+  /^[\s\0]*(?!tel:|fax:|sms:|skype:|callto:)[\w+.-]{2,}:\d+(?:[/?#\\]|$)/i;
 const PROTOCOL_REGEX = /^[\s\w\0+.-]{2,}:([/\\]{2})?/;
 const PROTOCOL_RELATIVE_REGEX = /^([/\\]\s*){2,}[^/\\]/;
 const PROTOCOL_SCRIPT_RE = /^[\s\0]*(blob|data|javascript|vbscript):$/i;
@@ -79,7 +81,7 @@ export function hasProtocol(
     return PROTOCOL_STRICT_REGEX.test(inputString);
   }
   return (
-    PROTOCOL_REGEX.test(inputString) ||
+    (PROTOCOL_REGEX.test(inputString) && !HOST_PORT_REGEX.test(inputString)) ||
     (opts.acceptRelative ? PROTOCOL_RELATIVE_REGEX.test(inputString) : false)
   );
 }
@@ -566,6 +568,9 @@ export function withoutProtocol(input: string): string {
  */
 export function withProtocol(input: string, protocol: string): string {
   let match = input.match(PROTOCOL_REGEX);
+  if (match && HOST_PORT_REGEX.test(input)) {
+    match = null;
+  }
   if (!match) {
     match = input.match(/^\/{2,}/);
   }

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -38,6 +38,14 @@ describe("parseURL", () => {
     },
     { input: "/test", out: { hash: "", pathname: "/test", search: "" } },
     {
+      input: "localhost:9000",
+      out: { hash: "", pathname: "localhost:9000", search: "" },
+    },
+    {
+      input: "localhost:9000/api",
+      out: { hash: "", pathname: "localhost:9000/api", search: "" },
+    },
+    {
       input: "file:///home/user",
       out: {
         auth: "",
@@ -293,4 +301,17 @@ describe("parseFilename", () => {
       ).toStrictEqual(t.out);
     });
   }
+});
+
+describe("parseURL with defaultProto", () => {
+  test("localhost:9000 with defaultProto", () => {
+    expect(structuredClone(parseURL("localhost:9000", "https://"))).toEqual({
+      protocol: "https:",
+      auth: "",
+      host: "localhost:9000",
+      pathname: "",
+      search: "",
+      hash: "",
+    });
+  });
 });

--- a/test/utilities.test.ts
+++ b/test/utilities.test.ts
@@ -42,6 +42,10 @@ describe("hasProtocol", () => {
     { input: "\0javascript:alert(true)", out: [true, false, true] },
     { input: "\0https://", out: [true, true, true] },
     { input: "tel:123456", out: [true, false, true] },
+    { input: "javascript:1234", out: [true, false, true] },
+    { input: "data:1234", out: [true, false, true] },
+    { input: "blob:1234", out: [true, false, true] },
+    { input: "custom+proto:1234", out: [true, false, true] },
     { input: "mailto:support@example.com", out: [true, false, true] },
 
     // Relative

--- a/test/utilities.test.ts
+++ b/test/utilities.test.ts
@@ -22,6 +22,11 @@ describe("hasProtocol", () => {
     { input: "///", out: [false, false, false] },
     { input: "C:/test", out: [false, false, false] },
     { input: "/test", out: [false, false, false] },
+    { input: "localhost:9000", out: [false, false, false] },
+    { input: "localhost:9000/foo", out: [false, false, false] },
+    { input: "127.0.0.1:8080", out: [false, false, false] },
+    { input: "example.com:3000?q=1", out: [false, false, false] },
+    { input: "my-host:80#hash", out: [false, false, false] },
 
     // Has protocol (strict)
     { input: "custom:/", out: [true, true, true] },
@@ -224,6 +229,31 @@ describe("withProtocol", () => {
       protocol: "callto://",
       out: "callto://+1234567890",
     },
+    {
+      input: "localhost:9000",
+      protocol: "http://",
+      out: "http://localhost:9000",
+    },
+    {
+      input: "localhost:9000",
+      protocol: "https://",
+      out: "https://localhost:9000",
+    },
+    {
+      input: "localhost:9000/api",
+      protocol: "http://",
+      out: "http://localhost:9000/api",
+    },
+    {
+      input: "127.0.0.1:8080",
+      protocol: "http://",
+      out: "http://127.0.0.1:8080",
+    },
+    {
+      input: "example.com:3000",
+      protocol: "https://",
+      out: "https://example.com:3000",
+    },
   ];
 
   for (const t of tests) {
@@ -247,6 +277,9 @@ describe("withoutProtocol", () => {
     { input: "mailto:support@example.com", out: "support@example.com" },
     { input: "skype:1234567890", out: "1234567890" },
     { input: "callto://+1234567890", out: "+1234567890" },
+    { input: "localhost:9000", out: "localhost:9000" },
+    { input: "127.0.0.1:8080", out: "127.0.0.1:8080" },
+    { input: "example.com:3000/test", out: "example.com:3000/test" },
   ];
 
   for (const t of tests) {


### PR DESCRIPTION
## Summary

Ensure `host:port` strings (such as `localhost:9000`, `127.0.0.1:8080`, or `example.com:3000`) are not incorrectly treated as having a protocol in `withProtocol`, `withHttp`, `withHttps`, `withoutProtocol`, and `hasProtocol`.

Fixes #237.

## Background

`PROTOCOL_REGEX` uses `([/\\]{2})?` to permit opaque, non-hierarchical schemes that do not include `//` (such as `mailto:`, `tel:`, `data:`). However, this caused hostnames followed by a port number (like `localhost:9000` or `127.0.0.1:8080`) to match as if the hostname were a protocol (`match[0] === "localhost:"`).

As a result:
- `withProtocol("localhost:9000", "http://")` returned `"http://9000"`, stripping the hostname.
- `withHttp("localhost:9000")` returned `"http://9000"`.
- `withoutProtocol("localhost:9000")` returned `"9000"`.
- `hasProtocol("localhost:9000")` returned `true`.
- `parseURL("localhost:9000")` lost both host and port.

This change adds `HOST_PORT_REGEX` to differentiate host-and-port patterns (excluding known non-hierarchical communication schemes like `tel:`, `fax:`, `sms:`, `skype:`, `callto:`) so that `withProtocol` prefixes the protocol instead of slicing out the hostname, and `hasProtocol` accurately reports `false`.

## Verification

- Added tests in `test/utilities.test.ts` for `hasProtocol`, `withProtocol`, and `withoutProtocol` with `localhost:9000`, `127.0.0.1:8080`, `example.com:3000`, etc.
- Added tests in `test/parse.test.ts` for `parseURL` with `localhost:9000` (including `defaultProto`).
- Verified all 507 tests pass (`pnpm test`).
- Verified linter and typecheck pass cleanly (`pnpm lint`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of host-and-port addresses such as `localhost:9000` and `127.0.0.1:8080`, including addresses with paths.
  * Automatically applies the default `https://` protocol to addresses without one.
  * Preserves host-and-port inputs correctly when removing protocols.
  * More accurately recognizes special URI schemes, including `javascript:`, `data:`, `blob:`, and others.

* **Tests**
  * Added coverage for host-and-port addresses and protocol detection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->