### PR TITLE
feat(utils): support withoutQuery utility

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -381,6 +381,28 @@ export function filterQuery(
 }
 
 /**
+ * Removes the query section of the URL.
+ *
+ * @example
+ *
+ * ```js
+ * withoutQuery("/foo?bar=1&baz=2"); // "/foo"
+ * withoutQuery("http://example.com/foo?q=123#bar"); // "http://example.com/foo#bar"
+ * ```
+ *
+ * @group utils
+ */
+export function withoutQuery(input: string): string {
+  if (!input.includes("?")) {
+    return input;
+  }
+
+  const parsed = parseURL(input);
+  parsed.search = "";
+  return stringifyParsedURL(parsed);
+}
+
+/**
  * Parses and decodes the query object of an input URL into an object.
  *
  * @example

--- a/test/utilities.test.ts
+++ b/test/utilities.test.ts
@@ -13,6 +13,7 @@ import {
   withFragment,
   withoutFragment,
   withoutHost,
+  withoutQuery,
 } from "../src";
 
 describe("hasProtocol", () => {
@@ -314,6 +315,49 @@ describe("withFragment", () => {
   for (const t of tests) {
     test(`${JSON.stringify(t.input)} + ${JSON.stringify(t.fragment)}`, () => {
       expect(withFragment(t.input, t.fragment)).toBe(t.out);
+    });
+  }
+});
+
+describe("withoutQuery", () => {
+  const tests = [
+    {
+      input: "https://example.com?foo=123",
+      out: "https://example.com",
+    },
+    {
+      input: "https://example.com",
+      out: "https://example.com",
+    },
+    {
+      input: "/foo?bar=1&baz=2",
+      out: "/foo",
+    },
+    {
+      input: "/foo/?bar=1",
+      out: "/foo/",
+    },
+    {
+      input: "/foo?bar=1#baz",
+      out: "/foo#baz",
+    },
+    {
+      input: "?foo=123",
+      out: "",
+    },
+    {
+      input: "?foo=123#hash",
+      out: "#hash",
+    },
+    {
+      input: "http://example.com/foo?q=123#bar",
+      out: "http://example.com/foo#bar",
+    },
+  ];
+
+  for (const t of tests) {
+    test(`${t.input}`, () => {
+      expect(withoutQuery(t.input)).toBe(t.out);
     });
   }
 });


### PR DESCRIPTION
## Problem

While `ufo` provides `withQuery` and `filterQuery` for adding or selectively filtering URL query parameters, as well as `withoutFragment`, `withoutHost`, and `withoutProtocol`, there was no dedicated helper to remove the query string completely while preserving paths, fragments, and relative base paths.

## Solution

- Added and exported `withoutQuery(input: string): string` to strip query strings from URLs.
- Includes an early exit when `?` is not present in the input.
- Preserves hashes, hosts, and paths.

## Testing

- Added unit tests in `test/utilities.test.ts` covering absolute URLs, relative URLs, paths with fragments, and empty query strings.
- Verified full test suite, TypeScript typechecks, and ESLint pass cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added functionality to remove query strings from URLs while preserving paths, fragments, and other URL components.

* **Tests**
  * Added coverage for URLs, paths, fragments, and inputs without query strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->