### PR TITLE
feat(utils): add withPathParameters utility

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,6 +5,7 @@ import {
   decodePath,
   encodeHash,
   encodeHost,
+  encodeParam,
   encodePath,
 } from "./encoding";
 
@@ -363,6 +364,63 @@ export function withQuery(input: string, query: QueryObject): string {
  *
  * @group utils
  */
+export interface WithPathParametersOptions {
+  /**
+   * The regex used to find path-parameter placeholders. Defaults to `/\{([\s\S]+?)\}/g`
+   * (curly braces); use `/{{([\s\S]+?)}}/g` for mustache-style templates or `/:([\w$]+)/g` for colon-style routes.
+   * Capturing group 1 is the parameter name (whitespace-trimmed).
+   *
+   * @default /\{([\s\S]+?)\}/g
+   */
+  interpolate?: RegExp;
+  /**
+   * Function used to encode parameter values.
+   *
+   * @default encodeParam
+   */
+  encode?: (value: string) => string;
+}
+
+/**
+ * Replace path parameter placeholders in a URL template with values.
+ *
+ * @example
+ * ```js
+ * withPathParameters('/api/users/{userId}', { userId: 'abc' });
+ * // '/api/users/abc'
+ *
+ * withPathParameters('/api/users/{userId}', { userId: 'foo/bar' });
+ * // '/api/users/foo%2Fbar'
+ *
+ * withPathParameters('/api/users/{{userId}}', { userId: 'abc' }, { interpolate: /\{\{([\s\S]+?)\}\}/g });
+ * // '/api/users/abc'
+ *
+ * withPathParameters('/api/users/:userId', { userId: 'abc' }, { interpolate: /:([\w$]+)/g });
+ * // '/api/users/abc'
+ * ```
+ *
+ * @group utils
+ */
+export function withPathParameters(
+  input: string,
+  parameters: Record<string, any>,
+  options: WithPathParametersOptions = {},
+): string {
+  const interpolate = options.interpolate || /\{([\s\S]+?)\}/g;
+  const encode = options.encode || encodeParam;
+
+  return input.replace(interpolate, (match, rawKey) => {
+    const key = String(rawKey).trim();
+    if (
+      !Object.prototype.hasOwnProperty.call(parameters, key) ||
+      parameters[key] == null
+    ) {
+      return match;
+    }
+    return encode(String(parameters[key]));
+  });
+}
+
 export function filterQuery(
   input: string,
   predicate: (key: string, value: string | string[]) => boolean,

--- a/test/utilities.test.ts
+++ b/test/utilities.test.ts
@@ -13,6 +13,7 @@ import {
   withFragment,
   withoutFragment,
   withoutHost,
+  withPathParameters,
 } from "../src";
 
 describe("hasProtocol", () => {
@@ -316,6 +317,81 @@ describe("withFragment", () => {
       expect(withFragment(t.input, t.fragment)).toBe(t.out);
     });
   }
+});
+
+describe("withPathParameters", () => {
+  test("basic parameter substitution", () => {
+    expect(withPathParameters("/api/users/{userId}", { userId: "abc" })).toBe(
+      "/api/users/abc",
+    );
+  });
+
+  test("multiple and numeric parameters", () => {
+    expect(
+      withPathParameters("/api/orgs/{orgId}/users/{userId}/posts/{postId}", {
+        orgId: "org-1",
+        userId: "user-2",
+        postId: 42,
+      }),
+    ).toBe("/api/orgs/org-1/users/user-2/posts/42");
+  });
+
+  test("encodes special characters in path parameters", () => {
+    expect(
+      withPathParameters("/search/{query}", { query: "hello world" }),
+    ).toBe("/search/hello%20world");
+    expect(withPathParameters("/files/{filePath}", { filePath: "a/b/c" })).toBe(
+      "/files/a%2Fb%2Fc",
+    );
+  });
+
+  test("supports trimmed whitespace in placeholder keys", () => {
+    expect(withPathParameters("/api/users/{ userId }", { userId: "123" })).toBe(
+      "/api/users/123",
+    );
+  });
+
+  test("preserves missing or null/undefined parameters", () => {
+    expect(
+      withPathParameters("/api/users/{userId}/{missing}", {
+        userId: "123",
+        missing: null,
+      }),
+    ).toBe("/api/users/123/{missing}");
+    expect(
+      withPathParameters("/api/users/{userId}/{missing}", {
+        userId: "123",
+      }),
+    ).toBe("/api/users/123/{missing}");
+  });
+
+  test("custom interpolate regex (mustache and colon styles)", () => {
+    expect(
+      withPathParameters(
+        "/api/users/{{userId}}",
+        { userId: "abc" },
+        { interpolate: /\{\{([\s\S]+?)\}\}/g },
+      ),
+    ).toBe("/api/users/abc");
+
+    expect(
+      withPathParameters(
+        "/api/users/:userId/posts/:postId",
+        { userId: "u1", postId: "p2" },
+        { interpolate: /:([\w$]+)/g },
+      ),
+    ).toBe("/api/users/u1/posts/p2");
+  });
+
+  test("custom encode function", () => {
+    expect(
+      withPathParameters(
+        "/files/{filePath}",
+        { filePath: "folder/subfolder/file.txt" },
+        { encode: (v) => v },
+      ),
+    ).toBe("/files/folder/subfolder/file.txt");
+  });
 });
 
 describe("withoutFragment", () => {


### PR DESCRIPTION
## Problem

When building client requests or generating dynamic endpoints from route templates, developers need to interpolate named path parameters into URLs. Currently `ufo` provides `withQuery` and `withBase`, but lacks a dedicated path templating helper to safely substitute placeholders with URL-encoded parameters.

## Solution

- Added and exported `withPathParameters(input, parameters, options)` and `WithPathParametersOptions` interface.
- Defaults to replacing `{param}` tokens using `encodeParam` (encoding `/` as `%2F` for single-segment parameters).
- Supports custom `interpolate` regular expressions (e.g. mustache `{{param}}` or colon-style `:param`).
- Supports custom `encode` functions for custom multi-segment path rules.
- Preserves unmatched or nullish (`null`/`undefined`) placeholders.

## Testing

- Added comprehensive unit tests in `test/utilities.test.ts` covering basic substitution, numeric values, special character encoding, whitespace-padded keys, missing/nullish placeholders, mustache/colon interpolation regexes, and custom encoders.
- Verified all 498 tests pass, TypeScript typechecks succeed without errors, and code style satisfies ESLint and Prettier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for replacing URL path placeholders with supplied parameter values.
  * Automatically encodes special characters for safe URL usage.
  * Supports custom placeholder formats and encoding behavior.
  * Preserves placeholders when values are missing or undefined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->