### PR TITLE
fix(withFragment): clear the fragment when passing an empty string

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -734,11 +734,11 @@ export function isEqual(a: string, b: string, options: CompareURLOptions = {}) {
  * @group utils
  */
 export function withFragment(input: string, hash: string): string {
-  if (!hash || hash === "#") {
+  if (hash === "#") {
     return input;
   }
   const parsed = parseURL(input);
-  parsed.hash = hash === "" ? "" : "#" + encodeHash(hash);
+  parsed.hash = hash ? "#" + encodeHash(hash) : "";
   return stringifyParsedURL(parsed);
 }
 

--- a/test/utilities.test.ts
+++ b/test/utilities.test.ts
@@ -291,6 +291,11 @@ describe("withFragment", () => {
     { input: "https://example.com", fragment: "", out: "https://example.com" },
     {
       input: "https://example.com#bar",
+      fragment: "",
+      out: "https://example.com",
+    },
+    {
+      input: "https://example.com#bar",
       fragment: "0",
       out: "https://example.com#0",
     },


### PR DESCRIPTION
### 🔍 Problem

`withFragment(input, "")` is documented to **remove** the fragment:

```js
withFragment("/foo#bar", ""); // "/foo"
```

…but it currently returns the input **unchanged**:

```js
withFragment("/foo#bar", "");            // ❌ "/foo#bar"
withFragment("https://example.com#bar", ""); // ❌ "https://example.com#bar"
```

### 🐞 Cause

```ts
export function withFragment(input: string, hash: string): string {
  if (!hash || hash === "#") {          // ← `!hash` also catches ""
    return input;
  }
  const parsed = parseURL(input);
  parsed.hash = hash === "" ? "" : "#" + encodeHash(hash); // ← this "" branch is dead
  return stringifyParsedURL(parsed);
}
```

The early-return guard uses `!hash`, which is truthy for the empty string, so it returns before the fragment can be cleared. That also makes the `hash === "" ? "" : …` branch on the next line unreachable — the code was clearly *intended* to support clearing via `""`, but never could.

### ✅ Fix

Only short-circuit on the `"#"` no-op case, and let a falsy hash fall through to clear the fragment:

```ts
export function withFragment(input: string, hash: string): string {
  if (hash === "#") {
    return input;
  }
  const parsed = parseURL(input);
  parsed.hash = hash ? "#" + encodeHash(hash) : "";
  return stringifyParsedURL(parsed);
}
```

Now `withFragment(url, "")` clears the fragment (matching the docstring and `withoutFragment`'s semantics), while non-empty fragments and the `"#"` no-op are unchanged.

| Call | Before | After |
|---|---|---|
| `withFragment("/foo#bar", "")` | `/foo#bar` | `/foo` |
| `withFragment("/foo#bar", "baz")` | `/foo#baz` | `/foo#baz` (unchanged) |
| `withFragment("/foo", "")` | `/foo` | `/foo` (unchanged) |
| `withFragment("/foo#bar", "#")` | `/foo#bar` | `/foo#bar` (unchanged) |

### 🧪 Tests

Added a `withFragment` case asserting an existing fragment is cleared by `""`. Full suite passes (`492 passed`, typecheck clean).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Empty fragment values now correctly remove existing URL fragments instead of leaving the URL unchanged.
  - A fragment value of `#` continues to preserve the original URL.

- **Tests**
  - Added coverage confirming that existing fragments are removed when an empty fragment is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->